### PR TITLE
Bugfix error in disallow-attribute-concatenation

### DIFF
--- a/lib/rules/disallow-attribute-concatenation.js
+++ b/lib/rules/disallow-attribute-concatenation.js
@@ -22,7 +22,7 @@ module.exports.prototype =
 
   , lint: function (file, errors) {
 
-      var regex = /['"]\s*\+|\+\s*['"]/
+      var regex = /\+(?=([^']*'[^']*')*[^']*$)/
 
       file.addErrorForAllLinesByType('attribute', regex, true, errors, 'Attribute concatenation must not be used')
 

--- a/test/rules/disallow-attribute-concatenation.test.js
+++ b/test/rules/disallow-attribute-concatenation.test.js
@@ -14,10 +14,15 @@ function createTest (linter, fixturesPath) {
 
       it('should report attribute concatenation', function () {
         assert.equal(linter.checkString('a(href=\'text \' + title) Link').length, 1)
+        assert.equal(linter.checkString('a(href=title + \'text \') Link').length, 1)
       })
 
       it('should not report attribute interpolation', function () {
         assert.equal(linter.checkString('a(href=\'#{title}\') Link').length, 0)
+        assert.equal(linter.checkString('img(src=\'logo.png\', alt=\'+G Logo\')').length, 0)
+        assert.equal(linter.checkString('img(src=\'logo.png\', alt=\'G+ Logo\')').length, 0)
+        assert.equal(linter.checkString('img(src=\'logo.png\', alt=\'G Logo+\')').length, 0)
+        assert.equal(linter.checkString('img(src=\'logo.png\', alt=\'+\')').length, 0)
       })
 
       it('should report multiple errors found in file', function () {


### PR DESCRIPTION
Modified disallow-attribute-concatenation regex to allow the + character within single quotes, but error when found outside of single quotes. Fixes #64 