### PR TITLE
Improves disallow block expansion

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -16,7 +16,22 @@ Pug must not contain any attribute interpolation operators.
 a(href='text #{title}') Link
 ```
 
-# disallowBlockExpansion: `true`
+# disallowBlockExpansion: `Array` | `true`
+
+## e.g.: `[ ]`
+
+Pug must not contain...
+
+```jade
+//- Invalid
+a(href='http://example.com', target='_blank'): img(src='http://example.com/image.jpg')
+
+//- Valid
+ul
+  li: a(href='http://example.com/1') Link 1
+```
+
+## if (true)
 
 Pug must not contain any block expansion operators.
 

--- a/lib/rules/disallow-block-expansion.js
+++ b/lib/rules/disallow-block-expansion.js
@@ -1,4 +1,19 @@
-// # disallowBlockExpansion: `true`
+// # disallowBlockExpansion: `Array` | `true`
+//
+// ## e.g.: `[ ]`
+//
+// Pug must not contain...
+//
+// ```jade
+// //- Invalid
+// a(href='http://example.com', target='_blank'): img(src='http://example.com/image.jpg')
+//
+// //- Valid
+// ul
+//   li: a(href='http://example.com/1') Link 1
+// ```
+//
+// ## if (true)
 //
 // Pug must not contain any block expansion operators.
 //
@@ -8,7 +23,8 @@
 // table: tr: td text
 // ```
 
-var utils = require('../utils')
+var assert = require('assert')
+  , utils = require('../utils')
 
 module.exports = function () {}
 
@@ -17,13 +33,39 @@ module.exports.prototype =
 
   , configure: function (options) {
 
-      utils.validateTrueOptions(this.name, options)
+      assert(typeof options === 'object' || options === true
+        , this.name + ' option requires an array, or a true value')
+
+      this._whiteList = options.whiteList
 
     }
 
   , lint: function (file, errors) {
 
-      file.addErrorForAllTokensByType(':', errors, 'Block expansion operators must not be used')
+      var whiteList = this._whiteList
+
+      if (whiteList) {
+        file.iterateTokensByType(':', function (token) {
+          var start = file.getPreviousTokenByType(token, utils.htmlTagBoundaryTypes)
+            , startIndex = start._index
+            , endIndex = token._index
+            , hasError = false
+
+          file.iterateTokensByFilter(function (token) {
+            return token._index > startIndex && token._index < endIndex
+          }, function (token) {
+            if (whiteList.indexOf(token.type) === -1) {
+              hasError = true
+            }
+          })
+
+          if (hasError) {
+            errors.add('Non-white listed tokens found before block expansion operator', token.line, token.col)
+          }
+        })
+      } else {
+        file.addErrorForAllTokensByType(':', errors, 'Block expansion operators must not be used')
+      }
 
     }
   }

--- a/test/fixtures/reporters/expected-disallow-block-expansion--console.txt
+++ b/test/fixtures/reporters/expected-disallow-block-expansion--console.txt
@@ -37,6 +37,8 @@ Block expansion operators must not be used
   > 8| table: tr: td: span Cell
 ------------^
     9| 
+    10| table(a='a', b='b'): tr: td: span Cell
+    11| 
 
 Block expansion operators must not be used
 
@@ -46,6 +48,8 @@ Block expansion operators must not be used
   > 8| table: tr: td: span Cell
 ----------------^
     9| 
+    10| table(a='a', b='b'): tr: td: span Cell
+    11| 
 
 Block expansion operators must not be used
 
@@ -55,5 +59,34 @@ Block expansion operators must not be used
   > 8| table: tr: td: span Cell
 --------------------^
     9| 
+    10| table(a='a', b='b'): tr: td: span Cell
+    11| 
+
+Block expansion operators must not be used
+
+%dirname%disallow-block-expansion.jade:10:20
+    8| table: tr: td: span Cell
+    9| 
+  > 10| table(a='a', b='b'): tr: td: span Cell
+---------------------------^
+    11| 
+
+Block expansion operators must not be used
+
+%dirname%disallow-block-expansion.jade:10:24
+    8| table: tr: td: span Cell
+    9| 
+  > 10| table(a='a', b='b'): tr: td: span Cell
+-------------------------------^
+    11| 
+
+Block expansion operators must not be used
+
+%dirname%disallow-block-expansion.jade:10:28
+    8| table: tr: td: span Cell
+    9| 
+  > 10| table(a='a', b='b'): tr: td: span Cell
+-----------------------------------^
+    11| 
 
 Block expansion operators must not be used

--- a/test/fixtures/reporters/expected-disallow-block-expansion--inline.txt
+++ b/test/fixtures/reporters/expected-disallow-block-expansion--inline.txt
@@ -4,4 +4,6 @@
 %dirname%disallow-block-expansion.jade:8:6 Block expansion operators must not be used
 %dirname%disallow-block-expansion.jade:8:10 Block expansion operators must not be used
 %dirname%disallow-block-expansion.jade:8:14 Block expansion operators must not be used
-
+%dirname%disallow-block-expansion.jade:10:20 Block expansion operators must not be used
+%dirname%disallow-block-expansion.jade:10:24 Block expansion operators must not be used
+%dirname%disallow-block-expansion.jade:10:28 Block expansion operators must not be used

--- a/test/fixtures/rules/disallow-block-expansion.jade
+++ b/test/fixtures/rules/disallow-block-expansion.jade
@@ -6,3 +6,5 @@ table
 table: tr: td Cell
 
 table: tr: td: span Cell
+
+table(a='a', b='b'): tr: td: span Cell

--- a/test/rules/disallow-block-expansion.test.js
+++ b/test/rules/disallow-block-expansion.test.js
@@ -6,6 +6,26 @@ function createTest (linter, fixturesPath) {
 
   describe('disallowBlockExpansion', function () {
 
+    describe('Array', function () {
+
+      before(function () {
+        linter.configure(
+        { disallowBlockExpansion:
+          { whiteList: 'tag'
+          }
+        })
+      })
+
+      it('should report multiple errors found in file', function () {
+        var result = linter.checkFile(fixturesPath + 'disallow-block-expansion.jade')
+
+        assert.equal(result.length, 1)
+        assert.equal(result[0].code, 'PUG:LINT_DISALLOWBLOCKEXPANSION')
+        assert.equal(result[0].line, 10)
+      })
+
+    })
+
     describe('true', function () {
 
       before(function () {
@@ -23,7 +43,7 @@ function createTest (linter, fixturesPath) {
       it('should report multiple errors found in file', function () {
         var result = linter.checkFile(fixturesPath + 'disallow-block-expansion.jade')
 
-        assert.equal(result.length, 6)
+        assert.equal(result.length, 9)
         assert.equal(result[0].code, 'PUG:LINT_DISALLOWBLOCKEXPANSION')
         assert.equal(result[0].line, 4)
         assert.equal(result[1].line, 6)


### PR DESCRIPTION
Adds support to white list particular tokens, so rather than banning the use of the block expansion operator entirely, it can be permitted in simple cases

e.g. `[ 'tag' ]` would allow `table: tr: td Text` but disallow `table(attr='attr): tr: td Text` because `tag` tokens are white listed, but attribute related tokens are not.

Will perhaps add an additional config variable so to check the limit of tokens
