### PR TITLE
Remove duplicate rule requireSpecificAttributes from rules.md

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -347,20 +347,6 @@ img(src='src')
 img(src='src' alt='alt')
 ```
 
-# requireSpecificAttributes: `Array`
-
-## e.g.: `[ { img: [ "alt" ] } ]`
-
-`img` tags must contain all of the attributes specified.
-
-```jade
-//- Invalid
-img(src='src')
-
-//- Valid
-img(src='src' alt='alt')
-```
-
 # requireStrictEqualityOperators: `true`
 
 Requires the use of `===` and `!==` instead of `==` and `!=`.

--- a/lib/rules/require-spaces-inside-attribute-brackets.js
+++ b/lib/rules/require-spaces-inside-attribute-brackets.js
@@ -9,20 +9,6 @@
 // //- Valid
 // input( type='text' name='name' value='value' )
 // ```
-//
-// # requireSpecificAttributes: `Array`
-//
-// ## e.g.: `[ { img: [ "alt" ] } ]`
-//
-// `img` tags must contain all of the attributes specified.
-//
-// ```jade
-// //- Invalid
-// img(src='src')
-//
-// //- Valid
-// img(src='src' alt='alt')
-// ```
 
 var utils = require('../utils')
 


### PR DESCRIPTION
The auto-generated `rules.md` had a duplicate rule in its description
for `requireSpecificAttributes`. The bug was due to the fact that an
unrelated rule `requireSpacesInsideAttributeBrackets` had an erroneous
duplicate description for the unrelated rule.

After removing the duplicate description and running `npm run docs`,
or more accurately `npm test`, the auto-generated `rules.md` file no
longer contains the duplicate rule.