### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ let g:syntastic_jade_checkers = ['jade_lint']
 
 ### Gulp
 
-If you're using Gulp as your build system, you can use [gulp-pug-lint](https://github.com/emartech/gulp-pug-lint) for easier integration.
+If you're using Gulp as your build system, you can use [gulp-pug-linter](https://github.com/ilyakam/gulp-pug-linter) for easier integration.
 
 ### Grunt
 


### PR DESCRIPTION
Change link to gulp-pug-linter

---

I humbly ask to point to my project [`gulp-pug-linter`](https://github.com/ilyakam/gulp-pug-linter) in this project's README file. It is objectively better because a) it accepts [all of the config files that are supported by `pug-lint`](https://github.com/pugjs/pug-lint/blob/master/lib/config-file.js#L6) and b) it has an option to break the CI build on lint errors. In addition, it comes with 100% code coverage and is currently under active development.

I've used commit f602190 as a template for my commit message above. Feel free revise it as you see fit.
