### PR TITLE
More accurate detection of attribute and string concatenation and interpolation

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -5,6 +5,9 @@ Pug must not contain any attribute concatenation.
 ```pug
 //- Invalid
 a(href='text ' + title) Link
+//- Invalid under `'aggressive'`
+a(href=text + title) Link
+a(href=num1 + num2) Link
 ```
 
 # disallowAttributeInterpolation: `true`
@@ -225,13 +228,15 @@ b Bold text
 i Italic text
 ```
 
-# disallowStringConcatenation: `true`
+# disallowStringConcatenation: `true` | `'aggressive'`
 
 Pug must not contain any string concatenation.
 
 ```pug
 //- Invalid
 h1= title + \'text\'
+//- Invalid under `'aggressive'`
+h1= title + text
 ```
 
 # disallowStringInterpolation: `true`

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -17,7 +17,16 @@ Pug must not contain any attribute interpolation operators.
 ```pug
 //- Invalid
 a(href='text #{title}') Link
+//- Valid
+a(href='text \#{title}') Link
+a(href='text \\#{title}') Link
 ```
+
+## Compatibility note
+
+Attribute interpolation has already been removed from Pug v2. This rule
+helps transition from legacy "Jade" v1 code bases to Pug, but does not serve
+any real purpose in real world if Pug v2 is used.
 
 # disallowBlockExpansion: `true`
 

--- a/lib/pug-file.js
+++ b/lib/pug-file.js
@@ -1,3 +1,5 @@
+var acorn = require('acorn');
+var acornWalk = require('acorn/dist/walk');
 var findLineColumn = require('find-line-column');
 var attrs = require('pug-attrs');
 var lexer = require('pug-lexer');
@@ -147,6 +149,32 @@ PugFile.prototype = {
         errors.add(message, token.line, token.col);
       });
     });
+  },
+
+  addErrorWithAcorn: function (token, cb, errors, message) {
+    var tokens = [];
+    var ast = acorn.parseExpressionAt(token.val, 0, {onToken: tokens});
+    var nodes = cb(ast, tokens);
+
+    nodes.forEach(function (node) {
+      var startLocation = this.findStartLocation(token.val, token, this.getNextToken(token));
+
+      /* istanbul ignore else: else branch is only a fallback */
+      if (startLocation) {
+        var loc = findLineColumn(token.val, node.start);
+
+        // loc.col is 0-based. Change it to 1-based.
+        loc.col++;
+        if (loc.line === 1) {
+          loc.col += startLocation.col - 1;
+        }
+
+        // loc.line is 1-based.
+        errors.add(message, startLocation.line + loc.line - 1, loc.col);
+      } else {
+        errors.add(message, token.line, token.col);
+      }
+    }.bind(this));
   },
 
   addErrorForConcatenation: function (token, errors, message) {

--- a/lib/pug-file.js
+++ b/lib/pug-file.js
@@ -1,3 +1,4 @@
+var findLineColumn = require('find-line-column');
 var attrs = require('pug-attrs');
 var lexer = require('pug-lexer');
 var utils = require('./utils');
@@ -197,6 +198,25 @@ PugFile.prototype = {
     });
   },
 
+  findStartLocation: function (value, start, end) {
+    var lines = this.getLines(start.line, end && end.line);
+    lines[lines.length - 1] = lines[lines.length - 1].substring(0, end.col);
+    var source = lines.join('\n');
+    var pos = source.indexOf(value, start.col - 1);
+
+    /* istanbul ignore if: this will only happen under odd circumstances like a
+     * lexer bug */
+    if (pos === -1) {
+      return null;
+    }
+
+    var loc = findLineColumn(source, pos);
+    return {
+      line: start.line + loc.line - 1,
+      col: loc.col + 1
+    };
+  },
+
   getCharacter: function (line, column) {
     return this.getLine(line).charAt(column - 1);
   },
@@ -230,8 +250,13 @@ PugFile.prototype = {
     return this._lines.slice(start, end);
   },
 
-  getNextTokenByType: function (current, type, direction) {
-    type = utils.createTypeArray(type);
+  getNextToken: function (current, direction) {
+    return this.getNextTokenByFilter(current, function () {
+      return true;
+    }, direction);
+  },
+
+  getNextTokenByFilter: function (current, filter, direction) {
     direction = direction === undefined ? 'next' : direction;
 
     var index = current._index;
@@ -241,10 +266,18 @@ PugFile.prototype = {
       index = direction === 'next' ? index + 1 : index - 1;
       current = this.getToken(index);
 
-      if (current && type.indexOf(current.type) !== -1) {
+      if (current && filter(current)) {
         return current;
       }
     }
+  },
+
+  getNextTokenByType: function (current, type, direction) {
+    type = utils.createTypeArray(type);
+
+    return this.getNextTokenByFilter(current, function (current) {
+      return type.indexOf(current.type) !== -1;
+    }, direction);
   },
 
   getParseErrors: function () {

--- a/lib/pug-file.js
+++ b/lib/pug-file.js
@@ -177,17 +177,25 @@ PugFile.prototype = {
     }.bind(this));
   },
 
-  addErrorForConcatenation: function (token, errors, message) {
-    var regex = new RegExp(utils.concatenationRegex);
-    var match = regex.exec(token.val);
-    var line = this.getLine(token.line);
-    var columnNumber;
+  // `aggressive` reports *any* addition as error.
+  addErrorForConcatenation: function (token, errors, message, aggressive) {
+    this.addErrorWithAcorn(token, function (ast, tokens) {
+      var badPlus = [];
 
-    if (match !== null) {
-      columnNumber = line.indexOf(token.val) + 1 + match.index + match[0].indexOf(match[1] || match[2]);
+      acornWalk.simple(ast, {
+        BinaryExpression: function (node) {
+          if (!badPlus.length && node.operator === '+' && (aggressive || isString(node.left) || isString(node.right))) {
+            badPlus.push(utils.getNextAcornToken(tokens, node.left.end));
+          }
+        }
+      });
 
-      errors.add(message, token.line, columnNumber);
-    }
+      return badPlus;
+
+      function isString(node) {
+        return node.type === 'Literal' && typeof node.value === 'string';
+      }
+    }, errors, message);
   },
 
   addErrorForLine: function (lineNumber, pattern, errors, message) {

--- a/lib/pug-file.js
+++ b/lib/pug-file.js
@@ -40,22 +40,6 @@ var PugFile = function (filename, source) {
 };
 
 PugFile.prototype = {
-  addErrorForAllLinesByFilter: function (filter, pattern, errors, message) {
-    var _this = this;
-
-    _this.iterateTokensByFilter(filter, function (token) {
-      _this.addErrorForLine(token.line, pattern, errors, message);
-    });
-  },
-
-  addErrorForAllLinesByType: function (type, pattern, errors, message) {
-    type = utils.createTypeArray(type);
-
-    this.addErrorForAllLinesByFilter(function (token) {
-      return type.indexOf(token.type) !== -1;
-    }, pattern, errors, message);
-  },
-
   addErrorForAllStaticAttributeValues: function (name, errors, message) {
     this.iterateTokensByFilter(function (token) {
       return token.type === 'attribute' && token.name.toLowerCase() === name.toLowerCase();
@@ -196,19 +180,6 @@ PugFile.prototype = {
         return node.type === 'Literal' && typeof node.value === 'string';
       }
     }, errors, message);
-  },
-
-  addErrorForLine: function (lineNumber, pattern, errors, message) {
-    var line = this.getLine(lineNumber);
-    var regex = new RegExp(pattern);
-    var match = regex.exec(line);
-    var columnNumber;
-
-    if (pattern.test(line)) {
-      columnNumber = 1 + match.index + match[0].indexOf(match[1]);
-
-      errors.add(message, lineNumber, columnNumber);
-    }
   },
 
   addErrorForMatch: function (a, b, isMatch, errors, message, lineNumber, columnNumber) {

--- a/lib/rules/disallow-attribute-concatenation.js
+++ b/lib/rules/disallow-attribute-concatenation.js
@@ -5,9 +5,12 @@
 // ```pug
 // //- Invalid
 // a(href='text ' + title) Link
+// //- Invalid under `'aggressive'`
+// a(href=text + title) Link
+// a(href=num1 + num2) Link
 // ```
 
-var utils = require('../utils');
+var assert = require('assert');
 
 module.exports = function () {};
 
@@ -15,12 +18,16 @@ module.exports.prototype = {
   name: 'disallowAttributeConcatenation',
 
   configure: function (options) {
-    utils.validateTrueOptions(this.name, options);
+    assert(options === true || options === 'aggressive',
+        this.name + ' option requires either a true value or "aggressive". Otherwise it should be removed');
+    this._aggressive = options === 'aggressive';
   },
 
   lint: function (file, errors) {
+    var _this = this;
+
     file.iterateTokensByType('attribute', function (token) {
-      file.addErrorForConcatenation(token, errors, 'Attribute concatenation must not be used');
+      file.addErrorForConcatenation(token, errors, 'Attribute concatenation must not be used', _this._aggressive);
     });
   }
 };

--- a/lib/rules/disallow-attribute-interpolation.js
+++ b/lib/rules/disallow-attribute-interpolation.js
@@ -5,7 +5,18 @@
 // ```pug
 // //- Invalid
 // a(href='text #{title}') Link
+// //- Valid
+// a(href='text \#{title}') Link
+// a(href='text \\#{title}') Link
 // ```
+//
+// ## Compatibility note
+//
+// Attribute interpolation has already been removed from Pug v2. This rule
+// helps transition from legacy "Jade" v1 code bases to Pug, but does not serve
+// any real purpose in real world if Pug v2 is used.
+
+var findLineColumn = require('find-line-column');
 
 var utils = require('../utils');
 
@@ -19,6 +30,16 @@ module.exports.prototype = {
   },
 
   lint: function (file, errors) {
-    file.addErrorForAllLinesByType('attribute', /\(.+([!#]){.+}.+\)/, errors, 'Attribute interpolation operators must not be used');
+    file.iterateTokensByType('attribute', function (token) {
+      var result = /(\\)?#\{.+\}/.exec(token.val);
+      if (result && !result[1]) {
+        var startLocation = file.findStartLocation(token.val, token, file.getNextToken(token));
+        var loc = findLineColumn(token.val, result.index);
+
+        loc.col += loc.line === 1 ? startLocation.col : 1;
+        loc.line += startLocation.line - 1;
+        errors.add('Attribute interpolation operators must not be used', loc.line, loc.col);
+      }
+    });
   }
 };

--- a/lib/rules/disallow-string-concatenation.js
+++ b/lib/rules/disallow-string-concatenation.js
@@ -1,13 +1,15 @@
-// # disallowStringConcatenation: `true`
+// # disallowStringConcatenation: `true` | `'aggressive'`
 //
 // Pug must not contain any string concatenation.
 //
 // ```pug
 // //- Invalid
 // h1= title + \'text\'
+// //- Invalid under `'aggressive'`
+// h1= title + text
 // ```
 
-var utils = require('../utils');
+var assert = require('assert');
 
 module.exports = function () {};
 
@@ -15,14 +17,18 @@ module.exports.prototype = {
   name: 'disallowStringConcatenation',
 
   configure: function (options) {
-    utils.validateTrueOptions(this.name, options);
+    assert(options === true || options === 'aggressive',
+        this.name + ' option requires either a true value or "aggressive". Otherwise it should be removed');
+    this._aggressive = options === 'aggressive';
   },
 
   lint: function (file, errors) {
+    var _this = this;
+
     file.iterateTokensByFilter(function (token) {
       return (token.type === 'code' && token.buffer);
     }, function (token) {
-      file.addErrorForConcatenation(token, errors, 'String concatenation must not be used');
+      file.addErrorForConcatenation(token, errors, 'String concatenation must not be used', _this._aggressive);
     });
   }
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -93,3 +93,11 @@ exports.htmlTagBoundaryTypes = [
 ];
 
 exports.concatenationRegex = /.['"]\s*(\+)|(\+)\s*['"]./;
+
+exports.getNextAcornToken = function (tokens, prevEnd) {
+  for (var i = 0; i < tokens.length; i++) {
+    if (tokens[i].start >= prevEnd) {
+      return tokens[i];
+    }
+  }
+};

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "posttest": "(istanbul check-coverage --statements 90 --branches 90 --functions 100 --lines 90 && rm -rf coverage) || echo Look at 'coverage/lcov-report/index.html' to find out more"
   },
   "dependencies": {
+    "acorn": "^3.1.0",
     "commander": "^2.9.0",
     "css-selector-parser": "^1.1.0",
     "find-line-column": "^0.5.2",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
   "dependencies": {
     "commander": "^2.9.0",
     "css-selector-parser": "^1.1.0",
+    "find-line-column": "^0.5.2",
     "glob": "^7.0.3",
     "minimatch": "^3.0.0",
     "path-is-absolute": "^1.0.0",

--- a/test/fixtures/rules/disallow-attribute-interpolation.pug
+++ b/test/fixtures/rules/disallow-attribute-interpolation.pug
@@ -13,6 +13,7 @@ a(href='#{title}') Link
 a(href='text ' + title) Link
 a(href=title + "text")
 a(href='text #{title}')
+a(href='text \#{title}')
 
 - var msg = "not my inside voice";
 p This is #{msg.toUpperCase()}

--- a/test/rules.test.js
+++ b/test/rules.test.js
@@ -1,3 +1,4 @@
+var assert = require('assert');
 var path = require('path');
 var glob = require('glob');
 var Linter = require('../lib/linter');
@@ -12,6 +13,15 @@ describe('rules', function () {
   });
 
   tests.forEach(function (test) {
-    test(linter, fixturesPath);
+    test(linter, fixturesPath, testSingle);
   });
+
+  function testSingle(source, line, column) {
+    var results = linter.checkString(source);
+    assert.equal(results.length, line ? 1 : 0);
+    if (line) {
+      assert.equal(results[0].line, line);
+      assert.equal(results[0].column, column);
+    }
+  }
 });

--- a/test/rules/disallow-attribute-concatenation.test.js
+++ b/test/rules/disallow-attribute-concatenation.test.js
@@ -2,7 +2,7 @@ module.exports = createTest;
 
 var assert = require('assert');
 
-function createTest(linter, fixturesPath) {
+function createTest(linter, fixturesPath, test) {
   describe('disallowAttributeConcatenation', function () {
     describe('true', function () {
       before(function () {
@@ -10,18 +10,52 @@ function createTest(linter, fixturesPath) {
       });
 
       it('should report attribute concatenation', function () {
-        assert.equal(linter.checkString('a(href=\'text \' + title) Link').length, 1);
-        assert.equal(linter.checkString('a(href=title + \'text \') Link').length, 1);
-        assert.equal(linter.checkString('a(href=title + "text ") Link').length, 1);
-        assert.equal(linter.checkString('a(href=title + title)').length, 0);
-        assert.equal(linter.checkString('img(src=\'logo.png\', alt=\'+G Logo\')').length, 0);
-        assert.equal(linter.checkString('img(src="logo.png", alt="G+ Logo")').length, 0);
-        assert.equal(linter.checkString('img(src=\'logo.png\', alt=\'G Logo+\')').length, 0);
-        assert.equal(linter.checkString('img(src=\'logo.png\', alt=\'+\')').length, 0);
+        test('a(href=\'text \' + title) Link', 1, 16);
+        test('a(href=title + \'text \') Link', 1, 14);
+        test('a(href=title+"text ") Link', 1, 13);
+        test('a(href=title + title)');
+        test('a(href=\'text \'\n + title) Link', 2, 2);
+        test('a(href=\n  \'text \' + title) Link', 2, 11);
+        test('img(src=\'logo.png\', alt=\'+G Logo\')');
+        test('img(src="logo.png", alt="G+ Logo")');
+        test('img(src=\'logo.png\', alt=\'G Logo+\')');
+        test('img(src=\'logo.png\', alt=\'+\')');
       });
 
-      it('should not report attribute interpolation', function () {
-        assert.equal(linter.checkString('a(href=\'#{title}\') Link').length, 0);
+      it('should not report attribute as template string', function () {
+        assert.equal(linter.checkString('a(href=`https://${link}`) Link').length, 0);
+      });
+
+      it('should report multiple errors found in file', function () {
+        var result = linter.checkFile(fixturesPath + 'disallow-attribute-concatenation.pug');
+
+        assert.equal(result.length, 3);
+        assert.equal(result[0].code, 'PUG:LINT_DISALLOWATTRIBUTECONCATENATION');
+        assert.equal(result[0].line, 13);
+        assert.equal(result[0].column, 16);
+      });
+    });
+
+    describe('aggressive', function () {
+      before(function () {
+        linter.configure({disallowAttributeConcatenation: 'aggressive'});
+      });
+
+      it('should report attribute concatenation', function () {
+        test('a(href=\'text \' + title) Link', 1, 16);
+        test('a(href=title + \'text \') Link', 1, 14);
+        test('a(href=title + "text ") Link', 1, 14);
+        test('a(href=title + title)', 1, 14);
+        test('a(href=\'text \'\n + title) Link', 2, 2);
+        test('a(href=\n  \'text \' + title) Link', 2, 11);
+        test('img(src=\'logo.png\', alt=\'+G Logo\')');
+        test('img(src="logo.png", alt="G+ Logo")');
+        test('img(src=\'logo.png\', alt=\'G Logo+\')');
+        test('img(src=\'logo.png\', alt=\'+\')');
+      });
+
+      it('should not report attribute as template string', function () {
+        assert.equal(linter.checkString('a(href=`https://${link}`) Link').length, 0);
       });
 
       it('should report multiple errors found in file', function () {

--- a/test/rules/disallow-string-concatenation.test.js
+++ b/test/rules/disallow-string-concatenation.test.js
@@ -2,7 +2,7 @@ module.exports = createTest;
 
 var assert = require('assert');
 
-function createTest(linter, fixturesPath) {
+function createTest(linter, fixturesPath, test) {
   describe('disallowStringConcatenation', function () {
     describe('true', function () {
       before(function () {
@@ -10,14 +10,42 @@ function createTest(linter, fixturesPath) {
       });
 
       it('should report string concatenation', function () {
-        assert.equal(linter.checkString('h1= title + \'text\'').length, 1);
-        assert.equal(linter.checkString('h1(class="test" + "test")= title + \'text\'').length, 1);
-        assert.equal(linter.checkString('h1= \'text+\'').length, 0);
-        assert.equal(linter.checkString('h1= test + test').length, 0);
+        test('h1= title + \'text\'', 1, 11);
+        test('h1(class="test" + "test")= title + \'text\'', 1, 34);
+        test('h1(class="test" + "test")= title + text');
+        test('h1= \'text+\'');
+        test('= test + test');
       });
 
       it('should not report string interpolation', function () {
-        assert.equal(linter.checkString('h1 #{title} text').length, 0);
+        test('h1 #{title} text');
+      });
+
+      it('should report multiple errors found in file', function () {
+        var result = linter.checkFile(fixturesPath + 'disallow-string-concatenation.pug');
+
+        assert.equal(result.length, 2);
+        assert.equal(result[0].code, 'PUG:LINT_DISALLOWSTRINGCONCATENATION');
+        assert.equal(result[0].line, 7);
+        assert.equal(result[0].column, 11);
+      });
+    });
+
+    describe('aggressive', function () {
+      before(function () {
+        linter.configure({disallowStringConcatenation: 'aggressive'});
+      });
+
+      it('should report string concatenation', function () {
+        test('h1= title + \'text\'', 1, 11);
+        test('h1(class="test" + "test")= title + \'text\'', 1, 34);
+        test('h1(class="test" + "test")= title + text', 1, 34);
+        test('h1= \'text+\'');
+        test('= test + test', 1, 8);
+      });
+
+      it('should not report string interpolation', function () {
+        test('h1 #{title} text');
       });
 
       it('should report multiple errors found in file', function () {


### PR DESCRIPTION
For concatenation rules, parse JavaScript using Acorn, and then examine the AST.

For attribute interpolation, fix false positive of `!{}` (it was not allowed in attributes and was passed through) and some corner cases. Also indicate that this rule is only of historic interest (for Jade v1 or migration to Pug).

Closes #76.