### PR TITLE
Add require-strict-extensions rule

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -466,6 +466,25 @@ div.class(class='class')
 .class(class='class')
 ```
 
+# validateExtensions: `true`
+
+Pug template must use proper file extensions with inclusion and inheritance
+(`.pug`).
+
+```pug
+//- Invalid
+include a
+include a.jade
+extends a
+extends a.txt
+extends a.jade
+
+//- Valid
+include a.txt
+include a.pug
+extends a.pug
+```
+
 # validateIndentation: `int` | `"\t"`
 
 ## e.g.: `2`

--- a/lib/rules/validate-extensions.js
+++ b/lib/rules/validate-extensions.js
@@ -1,0 +1,57 @@
+// # validateExtensions: `true`
+//
+// Pug template must use proper file extensions with inclusion and inheritance
+// (`.pug`).
+//
+// ```pug
+// //- Invalid
+// include a
+// include a.jade
+// extends a
+// extends a.txt
+// extends a.jade
+//
+// //- Valid
+// include a.txt
+// include a.pug
+// extends a.pug
+// ```
+
+var path = require('path');
+var utils = require('../utils');
+
+module.exports = function () {};
+
+module.exports.prototype = {
+  name: 'validateExtensions',
+
+  configure: function (options) {
+    utils.validateTrueOptions(this.name, options);
+  },
+
+  lint: function (file, errors) {
+    var tokens = file.getTokensByFilter(function (token) {
+      return token.type === 'include' || token.type === 'extends' || token.type === 'path';
+    });
+
+    tokens.forEach(function (token, i) {
+      var next = tokens[i + 1];
+
+      if (!next || next.type !== 'path') {
+        return;
+      }
+
+      if (token.type === 'include') {
+        if (path.basename(next.val).indexOf('.') === -1) {
+          errors.add('Included file path must have a file extension', next.line, next.col);
+        } else if (path.extname(next.val) === '.jade') {
+          errors.add('Included Pug file must end in .pug', next.line, next.col);
+        }
+      } else if (token.type === 'extends') {
+        if (path.extname(next.val) !== '.pug') {
+          errors.add('Extended Pug file must end in .pug', next.line, next.col);
+        }
+      }
+    });
+  }
+};

--- a/test/fixtures/rules/validate-extensions.pug
+++ b/test/fixtures/rules/validate-extensions.pug
@@ -1,0 +1,8 @@
+include a
+include a.jade
+include a.txt
+include a.pug
+extends a
+extends a.jade
+extends a.txt
+extends a.pug

--- a/test/rules/validate-extensions.test.js
+++ b/test/rules/validate-extensions.test.js
@@ -1,0 +1,58 @@
+module.exports = createTest;
+
+var assert = require('assert');
+
+function createTest(linter, fixturesPath) {
+  describe('validateExtensions', function () {
+    describe('true', function () {
+      before(function () {
+        linter.configure({validateExtensions: true});
+      });
+
+      it('should report include no extensions', function () {
+        assert.equal(linter.checkString('include a').length, 1);
+      });
+
+      it('should report include `.jade` extension', function () {
+        assert.equal(linter.checkString('include a.jade').length, 1);
+      });
+
+      it('should not report raw include extensions', function () {
+        assert.equal(linter.checkString('include a.txt').length, 0);
+      });
+
+      it('should not report include `.pug` extension', function () {
+        assert.equal(linter.checkString('include a.pug').length, 0);
+      });
+
+      it('should report extends no extensions', function () {
+        assert.equal(linter.checkString('extends a').length, 1);
+      });
+
+      it('should report extends `.jade` extension', function () {
+        assert.equal(linter.checkString('extends a.jade').length, 1);
+      });
+
+      it('should report other extends extensions', function () {
+        assert.equal(linter.checkString('extends a.txt').length, 1);
+      });
+
+      it('should not report extends `.pug` extension', function () {
+        assert.equal(linter.checkString('extends a.pug').length, 0);
+      });
+
+      it('should report multiple errors found in file', function () {
+        var result = linter.checkFile(fixturesPath + 'validate-extensions.pug');
+
+        assert.equal(result.length, 5);
+        assert.equal(result[0].code, 'PUG:LINT_VALIDATEEXTENSIONS');
+        assert.equal(result[0].line, 1);
+        assert.equal(result[0].column, 9);
+        assert.equal(result[1].line, 2);
+        assert.equal(result[2].line, 5);
+        assert.equal(result[3].line, 6);
+        assert.equal(result[4].line, 7);
+      });
+    });
+  });
+}


### PR DESCRIPTION
Can be used for Jade → Pug migration.