### PR TITLE
Update outdated dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,12 +80,12 @@
     "posttest": "(istanbul check-coverage --statements 90 --branches 90 --functions 100 --lines 90 && rimraf coverage) || echo Look at 'coverage/lcov-report/index.html' to find out more"
   },
   "dependencies": {
-    "acorn": "^3.1.0",
+    "acorn": "^4.0.1",
     "commander": "^2.9.0",
     "css-selector-parser": "^1.1.0",
     "find-line-column": "^0.5.2",
     "glob": "^7.0.3",
-    "minimatch": "^3.0.0",
+    "minimatch": "^3.0.3",
     "path-is-absolute": "^1.0.0",
     "pug-attrs": "^2.0.1",
     "pug-error": "^1.3.0",


### PR DESCRIPTION
minimatch had a [vulnerability](https://david-dm.org/pugjs/pug-lint); acorn was outdated.

Ran the tests and nothing broke. 