### PR TITLE
Corrects message for requireLowerCaseAttributes

### DIFF
--- a/lib/rules/require-lower-case-attributes.js
+++ b/lib/rules/require-lower-case-attributes.js
@@ -31,7 +31,7 @@ module.exports.prototype = {
     if (!isXml) {
       file.iterateTokensByType('attribute', function (token) {
         if (token.name !== token.name.toLowerCase()) {
-          errors.add('All tags must be written in lower case', token.line, token.col);
+          errors.add('All attributes must be written in lower case', token.line, token.col);
         }
       });
     }


### PR DESCRIPTION
Typo fix: **tags** -> **attributes**

Guessing this message was originally copied from `requireLowerCaseTags`
