### PR TITLE
Escape asterisk and other regexp reserved characters for attribute match pattern for validate-attribute-separator

### DIFF
--- a/lib/rules/validate-attribute-separator.js
+++ b/lib/rules/validate-attribute-separator.js
@@ -90,8 +90,8 @@ module.exports.prototype = {
         }, function (token) {
           var value = typeof token.val === 'boolean' ? '' : token.val;
 
-          patterns.push(token.name + (value.length > 0 ? '\\s*\\!*=\\s*' : '') +
-              value.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&'));
+          patterns.push(getEscapedPattern(token.name) + (value.length > 0 ? '\\s*\\!*=\\s*' : '') +
+              getEscapedPattern(value));
 
           if (current === undefined) {
             current = token;
@@ -134,6 +134,10 @@ module.exports.prototype = {
       }
 
       return source;
+    }
+
+    function getEscapedPattern(literal) {
+      return literal.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&');
     }
   }
 };

--- a/test/rules/validate-attribute-separator.test.js
+++ b/test/rules/validate-attribute-separator.test.js
@@ -29,6 +29,12 @@ function createTest(linter, fixturesPath) {
         assert.equal(result[1].line, 3);
         assert.equal(result[1].column, 30);
       });
+
+      it('should not raise error on attribute having asterisk mark in name', function () {
+        assert.doesNotThrow(function () {
+          linter.checkString('input(*ngIf=\'editing\' type=\'text\' name=\'name\' value=\'value\')');
+        }, /Invalid regular expression/);
+      });
     });
 
     describe('comma', function () {


### PR DESCRIPTION
Fixes #116 - issue

I locally confirmed test is passing and coverage is 100%.
I'm new to make PR to open source. Please let me know if any fix points.
