### PR TITLE
Adds schema for better IDE completion, docs, and Intellisense

### DIFF
--- a/generators/rule-templates/rule.js
+++ b/generators/rule-templates/rule.js
@@ -21,6 +21,10 @@ module.exports = function () {};
 module.exports.prototype = {
   name: '<%- optionName %>',
 
+  schema: {
+    enum: [null, true]
+  },
+
   configure: function (options) {
 <% if (optionsType === 'true') { -%>
     utils.validateTrueOptions(this.name, options);

--- a/lib/rules/disallow-attribute-concatenation.js
+++ b/lib/rules/disallow-attribute-concatenation.js
@@ -17,6 +17,10 @@ module.exports = function () {};
 module.exports.prototype = {
   name: 'disallowAttributeConcatenation',
 
+  schema: {
+    enum: [null, true]
+  },
+
   configure: function (options) {
     assert(options === true || options === 'aggressive',
         this.name + ' option requires either a true value or "aggressive". Otherwise it should be removed');

--- a/lib/rules/disallow-attribute-interpolation.js
+++ b/lib/rules/disallow-attribute-interpolation.js
@@ -25,6 +25,10 @@ module.exports = function () {};
 module.exports.prototype = {
   name: 'disallowAttributeInterpolation',
 
+  schema: {
+    enum: [null, true]
+  },
+
   configure: function (options) {
     utils.validateTrueOptions(this.name, options);
   },

--- a/lib/rules/disallow-attribute-template-string.js
+++ b/lib/rules/disallow-attribute-template-string.js
@@ -28,6 +28,10 @@ module.exports = function () {};
 module.exports.prototype = {
   name: 'disallowAttributeTemplateString',
 
+  schema: {
+    enum: [null, true, 'all']
+  },
+
   configure: function (options) {
     assert(options === true || options === 'all',
         this.name + ' option requires either a true value or "all". Otherwise it should be removed');

--- a/lib/rules/disallow-block-expansion.js
+++ b/lib/rules/disallow-block-expansion.js
@@ -15,6 +15,10 @@ module.exports = function () {};
 module.exports.prototype = {
   name: 'disallowBlockExpansion',
 
+  schema: {
+    enum: [null, true]
+  },
+
   configure: function (options) {
     utils.validateTrueOptions(this.name, options);
   },

--- a/lib/rules/disallow-class-attribute-with-static-value.js
+++ b/lib/rules/disallow-class-attribute-with-static-value.js
@@ -17,6 +17,10 @@ module.exports = function () {};
 module.exports.prototype = {
   name: 'disallowClassAttributeWithStaticValue',
 
+  schema: {
+    enum: [null, true]
+  },
+
   configure: function (options) {
     utils.validateTrueOptions(this.name, options);
   },

--- a/lib/rules/disallow-class-literals-before-attributes.js
+++ b/lib/rules/disallow-class-literals-before-attributes.js
@@ -17,6 +17,10 @@ module.exports = function () {};
 module.exports.prototype = {
   name: 'disallowClassLiteralsBeforeAttributes',
 
+  schema: {
+    enum: [null, true]
+  },
+
   contradictions: ['requireClassLiteralsBeforeAttributes'],
 
   configure: function (options) {

--- a/lib/rules/disallow-class-literals-before-id-literals.js
+++ b/lib/rules/disallow-class-literals-before-id-literals.js
@@ -17,6 +17,10 @@ module.exports = function () {};
 module.exports.prototype = {
   name: 'disallowClassLiteralsBeforeIdLiterals',
 
+  schema: {
+    enum: [null, true]
+  },
+
   contradictions: ['requireClassLiteralsBeforeIdLiterals'],
 
   configure: function (options) {

--- a/lib/rules/disallow-class-literals.js
+++ b/lib/rules/disallow-class-literals.js
@@ -17,6 +17,10 @@ module.exports = function () {};
 module.exports.prototype = {
   name: 'disallowClassLiterals',
 
+  schema: {
+    enum: [null, true]
+  },
+
   configure: function (options) {
     utils.validateTrueOptions(this.name, options);
   },

--- a/lib/rules/disallow-duplicate-attributes.js
+++ b/lib/rules/disallow-duplicate-attributes.js
@@ -20,6 +20,10 @@ module.exports = function () {};
 module.exports.prototype = {
   name: 'disallowDuplicateAttributes',
 
+  schema: {
+    enum: [null, true]
+  },
+
   configure: function (options) {
     utils.validateTrueOptions(this.name, options);
   },

--- a/lib/rules/disallow-html-text.js
+++ b/lib/rules/disallow-html-text.js
@@ -15,6 +15,10 @@ module.exports = function () {};
 module.exports.prototype = {
   name: 'disallowHtmlText',
 
+  schema: {
+    enum: [null, true]
+  },
+
   configure: function (options) {
     utils.validateTrueOptions(this.name, options);
   },

--- a/lib/rules/disallow-id-attribute-with-static-value.js
+++ b/lib/rules/disallow-id-attribute-with-static-value.js
@@ -17,6 +17,10 @@ module.exports = function () {};
 module.exports.prototype = {
   name: 'disallowIdAttributeWithStaticValue',
 
+  schema: {
+    enum: [null, true]
+  },
+
   configure: function (options) {
     utils.validateTrueOptions(this.name, options);
   },

--- a/lib/rules/disallow-id-literals-before-attributes.js
+++ b/lib/rules/disallow-id-literals-before-attributes.js
@@ -17,6 +17,10 @@ module.exports = function () {};
 module.exports.prototype = {
   name: 'disallowIdLiteralsBeforeAttributes',
 
+  schema: {
+    enum: [null, true]
+  },
+
   contradictions: ['requireIdLiteralsBeforeAttributes'],
 
   configure: function (options) {

--- a/lib/rules/disallow-id-literals.js
+++ b/lib/rules/disallow-id-literals.js
@@ -17,6 +17,10 @@ module.exports = function () {};
 module.exports.prototype = {
   name: 'disallowIdLiterals',
 
+  schema: {
+    enum: [null, true]
+  },
+
   configure: function (options) {
     utils.validateTrueOptions(this.name, options);
   },

--- a/lib/rules/disallow-legacy-mixin-call.js
+++ b/lib/rules/disallow-legacy-mixin-call.js
@@ -25,6 +25,10 @@ module.exports = function () {};
 module.exports.prototype = {
   name: 'disallowLegacyMixinCall',
 
+  schema: {
+    enum: [null, true]
+  },
+
   configure: function (options) {
     utils.validateTrueOptions(this.name, options);
   },

--- a/lib/rules/disallow-multiple-line-breaks.js
+++ b/lib/rules/disallow-multiple-line-breaks.js
@@ -22,6 +22,10 @@ module.exports = function () {};
 module.exports.prototype = {
   name: 'disallowMultipleLineBreaks',
 
+  schema: {
+    enum: [null, true]
+  },
+
   configure: function (options) {
     utils.validateTrueOptions(this.name, options);
   },

--- a/lib/rules/disallow-space-after-code-operator.js
+++ b/lib/rules/disallow-space-after-code-operator.js
@@ -33,6 +33,20 @@ module.exports = function () {};
 module.exports.prototype = {
   name: 'disallowSpaceAfterCodeOperator',
 
+  schema: {
+    anyOf: [
+      {
+        enum: [null, true]
+      },
+      {
+        type: 'array',
+        items: {
+          enum: ['-', '=', '!=']
+        }
+      }
+    ]
+  },
+
   configure: function (options) {
     this._codeOperatorTypes = utils.validateCodeOperatorOptions(this.name, options);
   },

--- a/lib/rules/disallow-spaces-inside-attribute-brackets.js
+++ b/lib/rules/disallow-spaces-inside-attribute-brackets.js
@@ -17,6 +17,10 @@ module.exports = function () {};
 module.exports.prototype = {
   name: 'disallowSpacesInsideAttributeBrackets',
 
+  schema: {
+    enum: [null, true]
+  },
+
   contradictions: ['requireSpacesInsideAttributeBrackets'],
 
   configure: function (options) {

--- a/lib/rules/disallow-specific-attributes.js
+++ b/lib/rules/disallow-specific-attributes.js
@@ -27,6 +27,19 @@ module.exports = function () {};
 module.exports.prototype = {
   name: 'disallowSpecificAttributes',
 
+  schema: {
+    type: ['null', 'string', 'array'],
+    items: {
+      type: ['object', 'string'],
+      additionalProperties: {
+        type: ['string', 'array'],
+        items: {
+          type: 'string'
+        }
+      }
+    }
+  },
+
   configure: function (options) {
     assert(typeof options === 'string' || Array.isArray(options), this.name + ' option requires string or array value or should be removed');
 

--- a/lib/rules/disallow-specific-tags.js
+++ b/lib/rules/disallow-specific-tags.js
@@ -17,6 +17,13 @@ module.exports = function () {};
 module.exports.prototype = {
   name: 'disallowSpecificTags',
 
+  schema: {
+    type: ['null', 'string', 'array'],
+    items: {
+      type: 'string'
+    }
+  },
+
   configure: function (options) {
     assert(typeof options === 'string' || Array.isArray(options), this.name + ' option requires string or array value or should be removed');
 

--- a/lib/rules/disallow-string-concatenation.js
+++ b/lib/rules/disallow-string-concatenation.js
@@ -16,6 +16,10 @@ module.exports = function () {};
 module.exports.prototype = {
   name: 'disallowStringConcatenation',
 
+  schema: {
+    enum: [null, true, 'aggressive']
+  },
+
   configure: function (options) {
     assert(options === true || options === 'aggressive',
         this.name + ' option requires either a true value or "aggressive". Otherwise it should be removed');

--- a/lib/rules/disallow-string-interpolation.js
+++ b/lib/rules/disallow-string-interpolation.js
@@ -14,6 +14,10 @@ module.exports = function () {};
 module.exports.prototype = {
   name: 'disallowStringInterpolation',
 
+  schema: {
+    enum: [null, true]
+  },
+
   configure: function (options) {
     utils.validateTrueOptions(this.name, options);
   },

--- a/lib/rules/disallow-tag-interpolation.js
+++ b/lib/rules/disallow-tag-interpolation.js
@@ -15,6 +15,10 @@ module.exports = function () {};
 module.exports.prototype = {
   name: 'disallowTagInterpolation',
 
+  schema: {
+    enum: [null, true]
+  },
+
   configure: function (options) {
     utils.validateTrueOptions(this.name, options);
   },

--- a/lib/rules/disallow-template-string.js
+++ b/lib/rules/disallow-template-string.js
@@ -28,6 +28,10 @@ module.exports = function () {};
 module.exports.prototype = {
   name: 'disallowTemplateString',
 
+  schema: {
+    enum: [null, true, 'all']
+  },
+
   configure: function (options) {
     assert(options === true || options === 'all',
         this.name + ' option requires either a true value or "all". Otherwise it should be removed');

--- a/lib/rules/maximum-number-of-lines.js
+++ b/lib/rules/maximum-number-of-lines.js
@@ -9,6 +9,10 @@ module.exports = function () {};
 module.exports.prototype = {
   name: 'maximumNumberOfLines',
 
+  schema: {
+    type: ['null', 'integer']
+  },
+
   configure: function (options) {
     assert(typeof options === 'number', this.name + ' option requires number value or should be removed');
 

--- a/lib/rules/require-class-literals-before-attributes.js
+++ b/lib/rules/require-class-literals-before-attributes.js
@@ -17,6 +17,10 @@ module.exports = function () {};
 module.exports.prototype = {
   name: 'requireClassLiteralsBeforeAttributes',
 
+  schema: {
+    enum: [null, true]
+  },
+
   contradictions: ['disallowClassLiteralsBeforeAttributes'],
 
   configure: function (options) {

--- a/lib/rules/require-class-literals-before-id-literals.js
+++ b/lib/rules/require-class-literals-before-id-literals.js
@@ -17,6 +17,10 @@ module.exports = function () {};
 module.exports.prototype = {
   name: 'requireClassLiteralsBeforeIdLiterals',
 
+  schema: {
+    enum: [null, true]
+  },
+
   contradictions: ['disallowClassLiteralsBeforeIdLiterals'],
 
   configure: function (options) {

--- a/lib/rules/require-id-literals-before-attributes.js
+++ b/lib/rules/require-id-literals-before-attributes.js
@@ -17,6 +17,10 @@ module.exports = function () {};
 module.exports.prototype = {
   name: 'requireIdLiteralsBeforeAttributes',
 
+  schema: {
+    enum: [null, true]
+  },
+
   contradictions: ['disallowIdLiteralsBeforeAttributes'],
 
   configure: function (options) {

--- a/lib/rules/require-line-feed-at-file-end.js
+++ b/lib/rules/require-line-feed-at-file-end.js
@@ -9,6 +9,10 @@ module.exports = function () {};
 module.exports.prototype = {
   name: 'requireLineFeedAtFileEnd',
 
+  schema: {
+    enum: [null, true]
+  },
+
   configure: function (options) {
     utils.validateTrueOptions(this.name, options);
   },

--- a/lib/rules/require-lower-case-attributes.js
+++ b/lib/rules/require-lower-case-attributes.js
@@ -17,6 +17,10 @@ module.exports = function () {};
 module.exports.prototype = {
   name: 'requireLowerCaseAttributes',
 
+  schema: {
+    enum: [null, true]
+  },
+
   configure: function (options) {
     utils.validateTrueOptions(this.name, options);
   },

--- a/lib/rules/require-lower-case-tags.js
+++ b/lib/rules/require-lower-case-tags.js
@@ -17,6 +17,10 @@ module.exports = function () {};
 module.exports.prototype = {
   name: 'requireLowerCaseTags',
 
+  schema: {
+    enum: [null, true]
+  },
+
   configure: function (options) {
     utils.validateTrueOptions(this.name, options);
   },

--- a/lib/rules/require-space-after-code-operator.js
+++ b/lib/rules/require-space-after-code-operator.js
@@ -33,6 +33,20 @@ module.exports = function () {};
 module.exports.prototype = {
   name: 'requireSpaceAfterCodeOperator',
 
+  schema: {
+    anyOf: [
+      {
+        enum: [null, true]
+      },
+      {
+        type: 'array',
+        items: {
+          enum: ['-', '=', '!=']
+        }
+      }
+    ]
+  },
+
   configure: function (options) {
     this._codeOperatorTypes = utils.validateCodeOperatorOptions(this.name, options);
   },

--- a/lib/rules/require-spaces-inside-attribute-brackets.js
+++ b/lib/rules/require-spaces-inside-attribute-brackets.js
@@ -17,6 +17,10 @@ module.exports = function () {};
 module.exports.prototype = {
   name: 'requireSpacesInsideAttributeBrackets',
 
+  schema: {
+    enum: [null, true]
+  },
+
   contradictions: ['disallowSpacesInsideAttributeBrackets'],
 
   configure: function (options) {

--- a/lib/rules/require-specific-attributes.js
+++ b/lib/rules/require-specific-attributes.js
@@ -21,6 +21,19 @@ module.exports = function () {};
 module.exports.prototype = {
   name: 'requireSpecificAttributes',
 
+  schema: {
+    type: ['null', 'array'],
+    items: {
+      type: 'object',
+      additionalProperties: {
+        type: 'array',
+        items: {
+          type: 'string'
+        }
+      }
+    }
+  },
+
   configure: function (options) {
     assert(Array.isArray(options), this.name + ' option requires array value or should be removed');
 

--- a/lib/rules/require-strict-equality-operators.js
+++ b/lib/rules/require-strict-equality-operators.js
@@ -19,6 +19,10 @@ module.exports = function () {};
 module.exports.prototype = {
   name: 'requireStrictEqualityOperators',
 
+  schema: {
+    enum: [null, true]
+  },
+
   configure: function (options) {
     utils.validateTrueOptions(this.name, options);
   },

--- a/lib/rules/validate-attribute-quote-marks.js
+++ b/lib/rules/validate-attribute-quote-marks.js
@@ -23,6 +23,10 @@ module.exports = function () {};
 module.exports.prototype = {
   name: 'validateAttributeQuoteMarks',
 
+  schema: {
+    enum: [null, '"', '\'', true]
+  },
+
   configure: function (options) {
     assert(options === '"' || options === '\'' || options === true, this.name + ' option requires \'"\', "\'", or a true value');
 

--- a/lib/rules/validate-attribute-separator.js
+++ b/lib/rules/validate-attribute-separator.js
@@ -48,6 +48,14 @@ module.exports = function () {};
 module.exports.prototype = {
   name: 'validateAttributeSeparator',
 
+  schema: {
+    type: ['null', 'string', 'object'],
+    properties: {
+      separator: {type: 'string'},
+      multiLineSeparator: {type: 'string'}
+    }
+  },
+
   configure: function (options) {
     assert(typeof options === 'string' || typeof options === 'object', this.name + ' option requires string or object value or should be removed');
 

--- a/lib/rules/validate-div-tags.js
+++ b/lib/rules/validate-div-tags.js
@@ -21,6 +21,10 @@ module.exports = function () {};
 module.exports.prototype = {
   name: 'validateDivTags',
 
+  schema: {
+    enum: [null, true]
+  },
+
   configure: function (options) {
     utils.validateTrueOptions(this.name, options);
   },

--- a/lib/rules/validate-extensions.js
+++ b/lib/rules/validate-extensions.js
@@ -25,6 +25,10 @@ module.exports = function () {};
 module.exports.prototype = {
   name: 'validateExtensions',
 
+  schema: {
+    enum: [null, true]
+  },
+
   configure: function (options) {
     utils.validateTrueOptions(this.name, options);
   },

--- a/lib/rules/validate-indentation.js
+++ b/lib/rules/validate-indentation.js
@@ -35,6 +35,17 @@ module.exports = function () {};
 module.exports.prototype = {
   name: 'validateIndentation',
 
+  schema: {
+    anyOf: [
+      {
+        enum: [null, '\t']
+      },
+      {
+        type: 'integer'
+      }
+    ]
+  },
+
   configure: function (options) {
     assert((typeof options === 'number' && options > 0) || options === '\t'
         , this.name + ' option requires a positive number of spaces or "\\t"');

--- a/lib/rules/validate-line-breaks.js
+++ b/lib/rules/validate-line-breaks.js
@@ -21,6 +21,10 @@ module.exports = function () {};
 module.exports.prototype = {
   name: 'validateLineBreaks',
 
+  schema: {
+    enum: [null, 'CR', 'LF', 'CRLF']
+  },
+
   configure: function (options) {
     assert(options === 'CR' || options === 'LF' || options === 'CRLF'
         , this.name + ' option requires "CR", "LF", or "CRLF"');

--- a/lib/rules/validate-self-closing-tags.js
+++ b/lib/rules/validate-self-closing-tags.js
@@ -26,6 +26,10 @@ module.exports = function () {};
 module.exports.prototype = {
   name: 'validateSelfClosingTags',
 
+  schema: {
+    enum: [null, true]
+  },
+
   configure: function (options) {
     utils.validateTrueOptions(this.name, options);
   },

--- a/lib/rules/validate-template-string.js
+++ b/lib/rules/validate-template-string.js
@@ -49,6 +49,20 @@ module.exports = function () {};
 module.exports.prototype = {
   name: 'validateTemplateString',
 
+  schema: {
+    anyOf: [
+      {
+        enum: [null, true]
+      },
+      {
+        type: 'array',
+        items: {
+          enum: ['variable', 'string', 'concatenation']
+        }
+      }
+    ]
+  },
+
   configure: function (options) {
     assert(options === true || Array.isArray(options), this.name + ' option requires a true or array value or should be removed');
 

--- a/package.json
+++ b/package.json
@@ -74,8 +74,9 @@
     "depcheck": "david",
     "coverage": "istanbul cover ./node_modules/mocha/bin/_mocha test",
     "docs": "pliers buildRuleDocs",
+    "schema": "pliers buildJsonSchema",
     "changelog": "pliers buildChangelog",
-    "pretest": "npm run docs && npm run lint",
+    "pretest": "npm run docs && npm run schema && npm run lint",
     "test": "npm run coverage",
     "posttest": "(istanbul check-coverage --statements 90 --branches 90 --functions 100 --lines 90 && rimraf coverage) || echo Look at 'coverage/lcov-report/index.html' to find out more"
   },

--- a/pliers/build-json-schema.js
+++ b/pliers/build-json-schema.js
@@ -1,0 +1,30 @@
+module.exports = createTask;
+
+var fs = require('fs');
+var path = require('path');
+var parseDocsFromRules = require('./parse-docs-from-rules');
+
+function createTask(pliers) {
+  pliers('buildJsonSchema', function (done) {
+    var fullSchema = require('../schemas/_template-schema.json');
+    var props = fullSchema.properties;
+    var docs = parseDocsFromRules(pliers);
+
+    docs.forEach(function (doc) {
+      var rule = require(doc.file).prototype;
+      var schema = rule.schema || {};
+      schema.description = doc.text.match(/\n\n(?:## .*?\n\n)?([\s\S]*?)\n(?:\n|$)/)[1];
+      schema.documentation = doc.text;
+      props[rule.name] = schema;
+    });
+
+    fs.writeFile(path.join(__dirname, '../schemas/pug-lintrc-schema.json'), JSON.stringify(fullSchema, null, '    '), 'utf8', function (error) {
+      if (error) {
+        pliers.logger.error('Failed to build JSON schema');
+        return done(error);
+      }
+
+      done();
+    });
+  });
+}

--- a/pliers/build-rule-docs.js
+++ b/pliers/build-rule-docs.js
@@ -2,34 +2,17 @@ module.exports = createTask;
 
 var fs = require('fs');
 var path = require('path');
-var docco = require('docco');
-var glob = require('glob');
+var parseDocsFromRules = require('./parse-docs-from-rules');
 
 function createTask(pliers) {
   pliers('buildRuleDocs', function (done) {
-    var rulesPattern = path.join(__dirname, '../lib/rules/*.js');
-    var docs = [];
+    var docs = parseDocsFromRules(pliers);
 
-    glob.sync(rulesPattern).forEach(function (file) {
-      var source = fs.readFileSync(file, 'utf8');
-      var hasDocs;
+    var concatenatedDocs = docs.map(function (doc) {
+      return doc.text;
+    }).join('\n');
 
-      docco.parse(file, source).map(function (section) {
-        if (!hasDocs && section.docsText) {
-          docs.push(section.docsText);
-          hasDocs = true;
-        }
-
-        return true;
-      });
-
-      if (!hasDocs) {
-        pliers.logger.error('Missing docs for rule:');
-        throw file;
-      }
-    });
-
-    fs.writeFile(path.join(__dirname, '../docs/rules.md'), docs.join('\n'), 'utf8', function (error) {
+    fs.writeFile(path.join(__dirname, '../docs/rules.md'), concatenatedDocs, 'utf8', function (error) {
       if (error) {
         pliers.logger.error('Failed to build rule docs');
         return done(error);

--- a/pliers/parse-docs-from-rules.js
+++ b/pliers/parse-docs-from-rules.js
@@ -1,0 +1,35 @@
+module.exports = parseDocsFromRules;
+
+var fs = require('fs');
+var path = require('path');
+var docco = require('docco');
+var glob = require('glob');
+
+function parseDocsFromRules(pliers) {
+  var rulesPattern = path.join(__dirname, '../lib/rules/*.js');
+  var docs = [];
+
+  glob.sync(rulesPattern).forEach(function (file) {
+    var source = fs.readFileSync(file, 'utf8');
+    var hasDocs;
+
+    docco.parse(file, source).map(function (section) {
+      if (!hasDocs && section.docsText) {
+        docs.push({
+          file: file,
+          text: section.docsText
+        });
+        hasDocs = true;
+      }
+
+      return true;
+    });
+
+    if (!hasDocs) {
+      pliers.logger.error('Missing docs for rule:');
+      throw file;
+    }
+  });
+
+  return docs;
+}

--- a/schemas/_template-schema.json
+++ b/schemas/_template-schema.json
@@ -1,0 +1,24 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "properties": {
+        "extends": {
+            "description": "If you want to extend a specific configuration file, you can use the extends property and specify the path to the file. The path can be either relative or absolute.",
+            "type": "string"
+        },
+        "excludeFiles": {
+            "description": "Disables style checking for specified paths declared with glob patterns.",
+            "default": ["node_modules/**"],
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "additionalRules": {
+          "description": "Array of file path matching patterns to load additional rules from.",
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        }
+    }
+}

--- a/schemas/pug-lintrc-schema.json
+++ b/schemas/pug-lintrc-schema.json
@@ -1,0 +1,449 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "properties": {
+        "preset": {
+            "description": "Deprecated",
+            "type": "string"
+        },
+        "extends": {
+            "type": "string"
+        },
+        "excludeFiles": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "additionalRules": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "disallowAttributeConcatenation": {
+          "enum": [null, true]
+        },
+        "disallowAttributeInterpolation": {
+            "description": "Pug must not contain any attribute interpolation operators.",
+            "documentation": "# disallowAttributeInterpolation: `true`\n\nPug must not contain any attribute interpolation operators.\n\n```pug\n//- Invalid\na(href='text #{title}') Link\n//- Valid\na(href='text \\#{title}') Link\na(href='text \\\\#{title}') Link\n```\n\n## Compatibility note\n\nAttribute interpolation has already been removed from Pug v2. This rule\nhelps transition from legacy \"Jade\" v1 code bases to Pug, but does not serve\nany real purpose in real world if Pug v2 is used.\n",
+            "enum": [
+                null,
+                true
+            ]
+        },
+        "disallowAttributeTemplateString": {
+            "description": "Pug must not contain template strings in attributes. `true` only fails when\nthe attribute is a template string; `'all'` fails when template strings are\nused at all.",
+            "documentation": "# disallowAttributeTemplateString: `true` | `'all'`\n\nPug must not contain template strings in attributes. `true` only fails when\nthe attribute is a template string; `'all'` fails when template strings are\nused at all.\n\n## e.g. `true`\n\n```pug\n//- Invalid\na(href=`https://${site}`) Link\n\n//- Valid\na(href=getLink(`https://${site}`)) Link\n```\n\n## e.g. `'all'`\n\n```pug\n//- Invalid\na(href=getLink(`https://${site}`)) Link\n```\n",
+            "enum": [
+                null,
+                true,
+                "all"
+            ]
+        },
+        "disallowBlockExpansion": {
+            "description": "Pug must not contain any block expansion operators.",
+            "documentation": "# disallowBlockExpansion: `true`\n\nPug must not contain any block expansion operators.\n\n```pug\n//- Invalid\np: strong text\ntable: tr: td text\n```\n",
+            "enum": [
+                null,
+                true
+            ]
+        },
+        "disallowClassAttributeWithStaticValue": {
+            "description": "Prefer class literals over `class` attributes with static values.",
+            "documentation": "# disallowClassAttributeWithStaticValue: `true`\n\nPrefer class literals over `class` attributes with static values.\n\n```pug\n//- Invalid\nspan(class='foo')\n\n//- Valid\nspan.foo\n```\n",
+            "enum": [
+                null,
+                true
+            ]
+        },
+        "disallowClassLiteralsBeforeAttributes": {
+            "description": "All attribute blocks must be written before any class literals.",
+            "documentation": "# disallowClassLiteralsBeforeAttributes: `true`\n\nAll attribute blocks must be written before any class literals.\n\n```pug\n//- Invalid\ninput.class(type='text')\n\n//- Valid\ninput(type='text').class\n```\n",
+            "enum": [
+                null,
+                true
+            ]
+        },
+        "disallowClassLiteralsBeforeIdLiterals": {
+            "description": "All ID literals must be written before any class literals.",
+            "documentation": "# disallowClassLiteralsBeforeIdLiterals: `true`\n\nAll ID literals must be written before any class literals.\n\n```pug\n//- Invalid\ninput.class#id(type='text')\n\n//- Valid\ninput#id.class(type='text')\n```\n",
+            "enum": [
+                null,
+                true
+            ]
+        },
+        "disallowClassLiterals": {
+            "description": "Pug must not contain any class literals.",
+            "documentation": "# disallowClassLiterals: `true`\n\nPug must not contain any class literals.\n\n```pug\n//- Invalid\n.class\n\n//- Valid\ndiv(class='class')\n```\n",
+            "enum": [
+                null,
+                true
+            ]
+        },
+        "disallowDuplicateAttributes": {
+            "description": "Attribute blocks must not contain any duplicates.\nAnd if an ID literal is present an ID attribute must not be used. Ignores class attributes.",
+            "documentation": "# disallowDuplicateAttributes: `true`\n\nAttribute blocks must not contain any duplicates.\nAnd if an ID literal is present an ID attribute must not be used. Ignores class attributes.\n\n```pug\n//- Invalid\ndiv(a='a' a='b')\n#id(id='id')\n\n//- Valid\ndiv(class='a', class='b')\n.class(class='class')\n```\n",
+            "enum": [
+                null,
+                true
+            ]
+        },
+        "disallowHtmlText": {
+            "description": "Pug must not contain any HTML text.",
+            "documentation": "# disallowHtmlText: `true`\n\nPug must not contain any HTML text.\n\n```pug\n//- Invalid\n<strong>html text</strong>\np this is <strong>html</strong> text\n```\n",
+            "enum": [
+                null,
+                true
+            ]
+        },
+        "disallowIdAttributeWithStaticValue": {
+            "description": "Prefer ID literals over `id` attributes with static values.",
+            "documentation": "# disallowIdAttributeWithStaticValue: `true`\n\nPrefer ID literals over `id` attributes with static values.\n\n```pug\n//- Invalid\nspan(id='foo')\n\n//- Valid\nspan#id\n```\n",
+            "enum": [
+                null,
+                true
+            ]
+        },
+        "disallowIdLiteralsBeforeAttributes": {
+            "description": "All attribute blocks must be written before any ID literals.",
+            "documentation": "# disallowIdLiteralsBeforeAttributes: `true`\n\nAll attribute blocks must be written before any ID literals.\n\n```pug\n//- Invalid\ninput#id(type='text')\n\n//- Valid\ninput(type='text')#id\n```\n",
+            "enum": [
+                null,
+                true
+            ]
+        },
+        "disallowIdLiterals": {
+            "description": "Pug must not contain any ID literals.",
+            "documentation": "# disallowIdLiterals: `true`\n\nPug must not contain any ID literals.\n\n```pug\n//- Invalid\n#id\n\n//- Valid\ndiv(id='id')\n```\n",
+            "enum": [
+                null,
+                true
+            ]
+        },
+        "disallowLegacyMixinCall": {
+            "description": "The Pug template must not contain legacy mixin call.",
+            "documentation": "# disallowLegacyMixinCall: `true`\n\nThe Pug template must not contain legacy mixin call.\n\n```pug\n//- Invalid\nmixin myMixin(arg)\n\n//- Valid mixin call\n+myMixin(arg)\n\n//- Valid mixin call with block attached\n+myMixin(arg)\n  p Hey\n\n//- Valid mixin definition\nmixin myMixin(arg)\n  p Hey\n```\n",
+            "enum": [
+                null,
+                true
+            ]
+        },
+        "disallowMultipleLineBreaks": {
+            "description": "Pug must not contain multiple blank lines in a row.",
+            "documentation": "# disallowMultipleLineBreaks: `true`\n\nPug must not contain multiple blank lines in a row.\n\n```pug\n//- Invalid\ndiv\n\n\ndiv\n\n//- Valid\ndiv\n\ndiv\n```\n",
+            "enum": [
+                null,
+                true
+            ]
+        },
+        "disallowSpaceAfterCodeOperator": {
+            "description": "No code operators (`-`/`=`/`!=`) should be followed by any spaces.",
+            "documentation": "# disallowSpaceAfterCodeOperator: `true` | `Array`\n\n## e.g.: `true`\n\nNo code operators (`-`/`=`/`!=`) should be followed by any spaces.\n\n```pug\n//- Invalid\np= 'This code is <escaped>'\np!=  'This code is <strong>not</strong> escaped'\n\n//- Valid\np='This code is <escaped>'\np!='This code is <strong>not</strong> escaped'\n```\n\n## e.g.: `[ \"-\" ]`\n\nNo unbuffered code operators (`-`) should be followed by any spaces.\n\n```pug\n//- Invalid\n- var a = 'This is code'\n\n//- Valid\n-var a = 'This is code'\n```\n",
+            "anyOf": [
+                {
+                    "enum": [
+                        null,
+                        true
+                    ]
+                },
+                {
+                    "type": "array",
+                    "items": {
+                        "enum": [
+                            "-",
+                            "=",
+                            "!="
+                        ]
+                    }
+                }
+            ]
+        },
+        "disallowSpacesInsideAttributeBrackets": {
+            "description": "Disallows space after opening attribute bracket and before closing.",
+            "documentation": "# disallowSpacesInsideAttributeBrackets: `true`\n\nDisallows space after opening attribute bracket and before closing.\n\n```pug\n//- Invalid\ninput( type='text' name='name' value='value' )\n\n//- Valid\ninput(type='text' name='name' value='value')\n```\n",
+            "enum": [
+                null,
+                true
+            ]
+        },
+        "disallowSpecificAttributes": {
+            "description": "Pug must not contain any of the attributes specified.",
+            "documentation": "# disallowSpecificAttributes: `string` | `Array`\n\n## e.g.: `\"a\"` OR `[ \"A\", \"b\" ]`\n\nPug must not contain any of the attributes specified.\n\n```pug\n//- Invalid\nspan(a='a')\ndiv(B='b')\n```\n\n## e.g.: `[ { img: [ \"title\" ] } ]`\n\n`img` tags must not contain any of the attributes specified.\n\n```pug\n//- Invalid\nimg(title='title')\n```\n",
+            "type": [
+                "null",
+                "string",
+                "array"
+            ],
+            "items": {
+                "type": [
+                    "object",
+                    "string"
+                ],
+                "additionalProperties": {
+                    "type": [
+                        "string",
+                        "array"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "disallowSpecificTags": {
+            "description": "Pug must not contain any of the tags specified.",
+            "documentation": "# disallowSpecificTags: `string` | `Array`\n\nPug must not contain any of the tags specified.\n\n## e.g.: `[ \"b\", \"i\" ]`\n\n```pug\n//- Invalid\nb Bold text\ni Italic text\n```\n",
+            "type": [
+                "null",
+                "string",
+                "array"
+            ],
+            "items": {
+                "type": "string"
+            }
+        },
+        "disallowStringConcatenation": {
+            "description": "Pug must not contain any string concatenation.",
+            "documentation": "# disallowStringConcatenation: `true` | `'aggressive'`\n\nPug must not contain any string concatenation.\n\n```pug\n//- Invalid\nh1= title + \\'text\\'\n//- Invalid under `'aggressive'`\nh1= title + text\n```\n",
+            "enum": [
+                null,
+                true,
+                "aggressive"
+            ]
+        },
+        "disallowStringInterpolation": {
+            "description": "Pug must not contain any string interpolation operators.",
+            "documentation": "# disallowStringInterpolation: `true`\n\nPug must not contain any string interpolation operators.\n\n```pug\n//- Invalid\nh1 #{title} text\n```\n",
+            "enum": [
+                null,
+                true
+            ]
+        },
+        "disallowTagInterpolation": {
+            "description": "Pug must not contain any tag interpolation operators.",
+            "documentation": "# disallowTagInterpolation: `true`\n\nPug must not contain any tag interpolation operators.\n\n```pug\n//- Invalid\n| #[strong html] text\np #[strong html] text\n```\n",
+            "enum": [
+                null,
+                true
+            ]
+        },
+        "disallowTemplateString": {
+            "description": "Pug must not contain template strings. `true` only fails when a template\nstring is used directly; `'all'` fails when template strings are used at\nall.",
+            "documentation": "# disallowTemplateString: `true` | `'all'`\n\nPug must not contain template strings. `true` only fails when a template\nstring is used directly; `'all'` fails when template strings are used at\nall.\n\n## e.g. `true`\n\n```pug\n//- Invalid\nh1= `${title} text`\n\n//- Valid\nh1= translate(`${title} text`)\n```\n\n## e.g. `'all'`\n\n```pug\n//- Invalid\nh1= translate(`${title} text`)\n```\n",
+            "enum": [
+                null,
+                true,
+                "all"
+            ]
+        },
+        "maximumNumberOfLines": {
+            "description": "Pug files should be at most the number of lines specified.",
+            "documentation": "# maximumNumberOfLines: `int`\n\nPug files should be at most the number of lines specified.\n",
+            "type": [
+                "null",
+                "integer"
+            ]
+        },
+        "requireClassLiteralsBeforeAttributes": {
+            "description": "All class literals must be written before any attribute blocks.",
+            "documentation": "# requireClassLiteralsBeforeAttributes: `true`\n\nAll class literals must be written before any attribute blocks.\n\n```pug\n//- Invalid\ninput(type='text').class\n\n//- Valid\ninput.class(type='text')\n```\n",
+            "enum": [
+                null,
+                true
+            ]
+        },
+        "requireClassLiteralsBeforeIdLiterals": {
+            "description": "All class literals must be written before any ID literals.",
+            "documentation": "# requireClassLiteralsBeforeIdLiterals: `true`\n\nAll class literals must be written before any ID literals.\n\n```pug\n//- Invalid\ninput#id.class(type='text')\n\n//- Valid\ninput.class#id(type='text')\n```\n",
+            "enum": [
+                null,
+                true
+            ]
+        },
+        "requireIdLiteralsBeforeAttributes": {
+            "description": "All ID literals must be written before any attribute blocks.",
+            "documentation": "# requireIdLiteralsBeforeAttributes: `true`\n\nAll ID literals must be written before any attribute blocks.\n\n```pug\n//- Invalid\ninput(type='text')#id\n\n//- Valid\ninput#id(type='text')\n```\n",
+            "enum": [
+                null,
+                true
+            ]
+        },
+        "requireLineFeedAtFileEnd": {
+            "description": "All files must end with a line feed.",
+            "documentation": "# requireLineFeedAtFileEnd: `true`\n\nAll files must end with a line feed.\n",
+            "enum": [
+                null,
+                true
+            ]
+        },
+        "requireLowerCaseAttributes": {
+            "description": "All attributes must be written in lower case. Files with `doctype xml` are ignored.",
+            "documentation": "# requireLowerCaseAttributes: `true`\n\nAll attributes must be written in lower case. Files with `doctype xml` are ignored.\n\n```pug\n//- Invalid\ndiv(Class='class')\n\n//- Valid\ndiv(class='class')\n```\n",
+            "enum": [
+                null,
+                true
+            ]
+        },
+        "requireLowerCaseTags": {
+            "description": "All tags must be written in lower case. Files with `doctype xml` are ignored.",
+            "documentation": "# requireLowerCaseTags: `true`\n\nAll tags must be written in lower case. Files with `doctype xml` are ignored.\n\n```pug\n//- Invalid\nDiv(class='class')\n\n//- Valid\ndiv(class='class')\n```\n",
+            "enum": [
+                null,
+                true
+            ]
+        },
+        "requireSpaceAfterCodeOperator": {
+            "description": "All code operators (`-`/`=`/`!=`) must be immediately followed by a single space.",
+            "documentation": "# requireSpaceAfterCodeOperator: `true` | `Array`\n\n## e.g.: `true`\n\nAll code operators (`-`/`=`/`!=`) must be immediately followed by a single space.\n\n```pug\n//- Invalid\np='This code is <escaped>'\np!=  'This code is <strong>not</strong> escaped'\n\n//- Valid\np= 'This code is <escaped>'\np!= 'This code is <strong>not</strong> escaped'\n```\n\n## e.g.: `[ \"-\" ]`\n\nAll unbuffered code operators (`-`) must be immediately followed by a single space.\n\n```pug\n//- Invalid\n-var a = 'This is code'\n\n//- Valid\n- var a = 'This is code'\n```\n",
+            "anyOf": [
+                {
+                    "enum": [
+                        null,
+                        true
+                    ]
+                },
+                {
+                    "type": "array",
+                    "items": {
+                        "enum": [
+                            "-",
+                            "=",
+                            "!="
+                        ]
+                    }
+                }
+            ]
+        },
+        "requireSpacesInsideAttributeBrackets": {
+            "description": "Requires space after opening attribute bracket and before closing.",
+            "documentation": "# requireSpacesInsideAttributeBrackets: `true`\n\nRequires space after opening attribute bracket and before closing.\n\n```pug\n//- Invalid\ninput(type='text' name='name' value='value')\n\n//- Valid\ninput( type='text' name='name' value='value' )\n```\n",
+            "enum": [
+                null,
+                true
+            ]
+        },
+        "requireSpecificAttributes": {
+            "description": "`img` tags must contain all of the attributes specified.",
+            "documentation": "# requireSpecificAttributes: `Array`\n\n## e.g.: `[ { img: [ \"alt\" ] } ]`\n\n`img` tags must contain all of the attributes specified.\n\n```pug\n//- Invalid\nimg(src='src')\n\n//- Valid\nimg(src='src' alt='alt')\n```\n",
+            "type": [
+                "null",
+                "array"
+            ],
+            "items": {
+                "type": "object",
+                "additionalProperties": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "requireStrictEqualityOperators": {
+            "description": "Requires the use of `===` and `!==` instead of `==` and `!=`.",
+            "documentation": "# requireStrictEqualityOperators: `true`\n\nRequires the use of `===` and `!==` instead of `==` and `!=`.\n\n```pug\n//- Invalid\nif true == false\nif true != false\n\n//- Valid\nif true === false\nif true !== false\n```\n",
+            "enum": [
+                null,
+                true
+            ]
+        },
+        "validateAttributeQuoteMarks": {
+            "description": "All attribute values must be enclosed in single quotes.",
+            "documentation": "# validateAttributeQuoteMarks: `\"\\\"\"` | `\"'\"` | `true`\n\n## e.g.: `\"'\"`\n\nAll attribute values must be enclosed in single quotes.\n\n```pug\n//- Invalid\ninput(type=\"text\" name=\"name\" value=\"value\")\n\n//- Valid\ninput(type='text' name='name' value='value')\n```\n\n## if (true)\n\nAll attribute values must be enclosed in quote marks match the first quote mark encountered in the source code.\n",
+            "enum": [
+                null,
+                "\"",
+                "'",
+                true
+            ]
+        },
+        "validateAttributeSeparator": {
+            "description": "* All attributes must be immediately followed by a comma and then a space.\n* All attributes must be on the same line.",
+            "documentation": "# validateAttributeSeparator: `string` | `object`\n\n## e.g.: `\", \"`\n\n* All attributes must be immediately followed by a comma and then a space.\n* All attributes must be on the same line.\n\n```pug\n//- Invalid\ninput(type='text' name='name' value='value')\ndiv\n  input(type='text'\n  , name='name'\n  , value='value'\n  )\n\n//- Valid\ninput(type='text', name='name', value='value')\n```\n\n## e.g.: `{ \"separator\": \" \", \"multiLineSeparator\": \"\\n  \" }`\n\n* All attributes that are on the same line must be immediately followed by a space.\n* All attributes that are on different lines must be preceded by two spaces.\n\n```pug\n//- Invalid\ninput(type='text', name='name', value='value')\ndiv\n  input(type='text'\n  , name='name'\n  , value='value'\n  )\n\n//- Valid\ninput(type='text' name='name' value='value')\ndiv\n  input(type='text'\n    name='name'\n    value='value'\n)\n```\n",
+            "type": [
+                "null",
+                "string",
+                "object"
+            ],
+            "properties": {
+                "separator": {
+                    "type": "string"
+                },
+                "multiLineSeparator": {
+                    "type": "string"
+                }
+            }
+        },
+        "validateDivTags": {
+            "description": "Checks that Pug does not contain any unnecessary `div` tags.",
+            "documentation": "# validateDivTags: `true`\n\nChecks that Pug does not contain any unnecessary `div` tags.\n\n```pug\n//- Invalid\ndiv.class\ndiv#id\ndiv.class(class='class')\n\n//- Valid\n.class\n#id\n.class(class='class')\n```\n",
+            "enum": [
+                null,
+                true
+            ]
+        },
+        "validateExtensions": {
+            "description": "Pug template must use proper file extensions with inclusion and inheritance\n(`.pug`).",
+            "documentation": "# validateExtensions: `true`\n\nPug template must use proper file extensions with inclusion and inheritance\n(`.pug`).\n\n```pug\n//- Invalid\ninclude a\ninclude a.jade\nextends a\nextends a.txt\nextends a.jade\n\n//- Valid\ninclude a.txt\ninclude a.pug\nextends a.pug\n```\n",
+            "enum": [
+                null,
+                true
+            ]
+        },
+        "validateIndentation": {
+            "description": "Indentation must be consistently two spaces.",
+            "documentation": "# validateIndentation: `int` | `\"\\t\"`\n\n## e.g.: `2`\n\nIndentation must be consistently two spaces.\n\n```pug\n//- Invalid\ndiv\n<TAB>div\n\n//- Valid\ndiv\n<SPACE><SPACE>div\n```\n\n## e.g.: `\"\\t\"`\n\nIndentation must be consistently tabs.\n\n```pug\n//- Invalid\ndiv\n<SPACE><SPACE>div\n\n//- Valid\ndiv\n<TAB>div\n```\n",
+            "anyOf": [
+                {
+                    "enum": [
+                        null,
+                        "\t"
+                    ]
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "validateLineBreaks": {
+            "description": "All line break characters must match.",
+            "documentation": "# validateLineBreaks: `\"CR\"` | `\"LF\"` | `\"CRLF\"`\n\n## e.g.: `\"LF\"`\n\nAll line break characters must match.\n\n```pug\n//- Invalid\ndiv(class='class')<CRLF>\n.button\n\n//- Valid\ndiv(class='class')<LF>\n.button\n```\n",
+            "enum": [
+                null,
+                "CR",
+                "LF",
+                "CRLF"
+            ]
+        },
+        "validateSelfClosingTags": {
+            "description": "Checks that Pug does not contain any\n[unnecessary self closing tags](http://www.w3.org/html/wg/drafts/html/master/syntax.html#void-elements).\nFiles with `doctype xml` are ignored.",
+            "documentation": "# validateSelfClosingTags: `true`\n\nChecks that Pug does not contain any\n[unnecessary self closing tags](http://www.w3.org/html/wg/drafts/html/master/syntax.html#void-elements).\nFiles with `doctype xml` are ignored.\n\n```pug\n//- Invalid\narea/\nlink/\n\n//- Valid\narea\nlink\nfoo/\n\ndoctype xml\narea/\n```\n",
+            "enum": [
+                null,
+                true
+            ]
+        },
+        "validateTemplateString": {
+            "description": "Validate the use of template string in Pug templates.",
+            "documentation": "# validateTemplateString: `true` | Array\n\nValidate the use of template string in Pug templates.\n\nThe option can either be an array or `true`. If it is an array, it can\ncontain the following strings. If it is `true` signifies all of the\nfollowing subrules are enabled.\n\n## `'variable'`\n\n```pug\n//- Invalid\nh1= `${title}`\n\n//- Valid\nh1= title\n```\n\n## `'string'`\n\n```pug\n//- Invalid\nh1= `title`\n\n//- Valid\nh1= 'title'\n```\n\n## `'concatenation'`\n\n```pug\n//- Invalid\nh1= `title` + `text`\nh1= `title` + variable\n\n//- Valid\nh1= `titletext`\nh1= `title${variable}`\n```",
+            "anyOf": [
+                {
+                    "enum": [
+                        null,
+                        true
+                    ]
+                },
+                {
+                    "type": "array",
+                    "items": {
+                        "enum": [
+                            "variable",
+                            "string",
+                            "concatenation"
+                        ]
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/schemas/pug-lintrc-schema.json
+++ b/schemas/pug-lintrc-schema.json
@@ -1,144 +1,149 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
     "properties": {
-        "preset": {
-            "description": "Deprecated",
-            "type": "string"
-        },
         "extends": {
+            "description": "If you want to extend a specific configuration file, you can use the extends property and specify the path to the file. The path can be either relative or absolute.",
             "type": "string"
         },
         "excludeFiles": {
+            "description": "Disables style checking for specified paths declared with glob patterns.",
+            "default": [
+                "node_modules/**"
+            ],
             "type": "array",
             "items": {
                 "type": "string"
             }
         },
         "additionalRules": {
+            "description": "Array of file path matching patterns to load additional rules from.",
             "type": "array",
             "items": {
                 "type": "string"
             }
         },
         "disallowAttributeConcatenation": {
-          "enum": [null, true]
-        },
-        "disallowAttributeInterpolation": {
-            "description": "Pug must not contain any attribute interpolation operators.",
-            "documentation": "# disallowAttributeInterpolation: `true`\n\nPug must not contain any attribute interpolation operators.\n\n```pug\n//- Invalid\na(href='text #{title}') Link\n//- Valid\na(href='text \\#{title}') Link\na(href='text \\\\#{title}') Link\n```\n\n## Compatibility note\n\nAttribute interpolation has already been removed from Pug v2. This rule\nhelps transition from legacy \"Jade\" v1 code bases to Pug, but does not serve\nany real purpose in real world if Pug v2 is used.\n",
             "enum": [
                 null,
                 true
-            ]
+            ],
+            "description": "Pug must not contain any attribute concatenation.",
+            "documentation": "# disallowAttributeConcatenation: `true`\n\nPug must not contain any attribute concatenation.\n\n```pug\n//- Invalid\na(href='text ' + title) Link\n//- Invalid under `'aggressive'`\na(href=text + title) Link\na(href=num1 + num2) Link\n```\n"
+        },
+        "disallowAttributeInterpolation": {
+            "enum": [
+                null,
+                true
+            ],
+            "description": "Pug must not contain any attribute interpolation operators.",
+            "documentation": "# disallowAttributeInterpolation: `true`\n\nPug must not contain any attribute interpolation operators.\n\n```pug\n//- Invalid\na(href='text #{title}') Link\n//- Valid\na(href='text \\#{title}') Link\na(href='text \\\\#{title}') Link\n```\n\n## Compatibility note\n\nAttribute interpolation has already been removed from Pug v2. This rule\nhelps transition from legacy \"Jade\" v1 code bases to Pug, but does not serve\nany real purpose in real world if Pug v2 is used.\n"
         },
         "disallowAttributeTemplateString": {
-            "description": "Pug must not contain template strings in attributes. `true` only fails when\nthe attribute is a template string; `'all'` fails when template strings are\nused at all.",
-            "documentation": "# disallowAttributeTemplateString: `true` | `'all'`\n\nPug must not contain template strings in attributes. `true` only fails when\nthe attribute is a template string; `'all'` fails when template strings are\nused at all.\n\n## e.g. `true`\n\n```pug\n//- Invalid\na(href=`https://${site}`) Link\n\n//- Valid\na(href=getLink(`https://${site}`)) Link\n```\n\n## e.g. `'all'`\n\n```pug\n//- Invalid\na(href=getLink(`https://${site}`)) Link\n```\n",
             "enum": [
                 null,
                 true,
                 "all"
-            ]
+            ],
+            "description": "Pug must not contain template strings in attributes. `true` only fails when\nthe attribute is a template string; `'all'` fails when template strings are\nused at all.",
+            "documentation": "# disallowAttributeTemplateString: `true` | `'all'`\n\nPug must not contain template strings in attributes. `true` only fails when\nthe attribute is a template string; `'all'` fails when template strings are\nused at all.\n\n## e.g. `true`\n\n```pug\n//- Invalid\na(href=`https://${site}`) Link\n\n//- Valid\na(href=getLink(`https://${site}`)) Link\n```\n\n## e.g. `'all'`\n\n```pug\n//- Invalid\na(href=getLink(`https://${site}`)) Link\n```\n"
         },
         "disallowBlockExpansion": {
-            "description": "Pug must not contain any block expansion operators.",
-            "documentation": "# disallowBlockExpansion: `true`\n\nPug must not contain any block expansion operators.\n\n```pug\n//- Invalid\np: strong text\ntable: tr: td text\n```\n",
             "enum": [
                 null,
                 true
-            ]
+            ],
+            "description": "Pug must not contain any block expansion operators.",
+            "documentation": "# disallowBlockExpansion: `true`\n\nPug must not contain any block expansion operators.\n\n```pug\n//- Invalid\np: strong text\ntable: tr: td text\n```\n"
         },
         "disallowClassAttributeWithStaticValue": {
-            "description": "Prefer class literals over `class` attributes with static values.",
-            "documentation": "# disallowClassAttributeWithStaticValue: `true`\n\nPrefer class literals over `class` attributes with static values.\n\n```pug\n//- Invalid\nspan(class='foo')\n\n//- Valid\nspan.foo\n```\n",
             "enum": [
                 null,
                 true
-            ]
+            ],
+            "description": "Prefer class literals over `class` attributes with static values.",
+            "documentation": "# disallowClassAttributeWithStaticValue: `true`\n\nPrefer class literals over `class` attributes with static values.\n\n```pug\n//- Invalid\nspan(class='foo')\n\n//- Valid\nspan.foo\n```\n"
         },
         "disallowClassLiteralsBeforeAttributes": {
-            "description": "All attribute blocks must be written before any class literals.",
-            "documentation": "# disallowClassLiteralsBeforeAttributes: `true`\n\nAll attribute blocks must be written before any class literals.\n\n```pug\n//- Invalid\ninput.class(type='text')\n\n//- Valid\ninput(type='text').class\n```\n",
             "enum": [
                 null,
                 true
-            ]
+            ],
+            "description": "All attribute blocks must be written before any class literals.",
+            "documentation": "# disallowClassLiteralsBeforeAttributes: `true`\n\nAll attribute blocks must be written before any class literals.\n\n```pug\n//- Invalid\ninput.class(type='text')\n\n//- Valid\ninput(type='text').class\n```\n"
         },
         "disallowClassLiteralsBeforeIdLiterals": {
-            "description": "All ID literals must be written before any class literals.",
-            "documentation": "# disallowClassLiteralsBeforeIdLiterals: `true`\n\nAll ID literals must be written before any class literals.\n\n```pug\n//- Invalid\ninput.class#id(type='text')\n\n//- Valid\ninput#id.class(type='text')\n```\n",
             "enum": [
                 null,
                 true
-            ]
+            ],
+            "description": "All ID literals must be written before any class literals.",
+            "documentation": "# disallowClassLiteralsBeforeIdLiterals: `true`\n\nAll ID literals must be written before any class literals.\n\n```pug\n//- Invalid\ninput.class#id(type='text')\n\n//- Valid\ninput#id.class(type='text')\n```\n"
         },
         "disallowClassLiterals": {
-            "description": "Pug must not contain any class literals.",
-            "documentation": "# disallowClassLiterals: `true`\n\nPug must not contain any class literals.\n\n```pug\n//- Invalid\n.class\n\n//- Valid\ndiv(class='class')\n```\n",
             "enum": [
                 null,
                 true
-            ]
+            ],
+            "description": "Pug must not contain any class literals.",
+            "documentation": "# disallowClassLiterals: `true`\n\nPug must not contain any class literals.\n\n```pug\n//- Invalid\n.class\n\n//- Valid\ndiv(class='class')\n```\n"
         },
         "disallowDuplicateAttributes": {
-            "description": "Attribute blocks must not contain any duplicates.\nAnd if an ID literal is present an ID attribute must not be used. Ignores class attributes.",
-            "documentation": "# disallowDuplicateAttributes: `true`\n\nAttribute blocks must not contain any duplicates.\nAnd if an ID literal is present an ID attribute must not be used. Ignores class attributes.\n\n```pug\n//- Invalid\ndiv(a='a' a='b')\n#id(id='id')\n\n//- Valid\ndiv(class='a', class='b')\n.class(class='class')\n```\n",
             "enum": [
                 null,
                 true
-            ]
+            ],
+            "description": "Attribute blocks must not contain any duplicates.\nAnd if an ID literal is present an ID attribute must not be used. Ignores class attributes.",
+            "documentation": "# disallowDuplicateAttributes: `true`\n\nAttribute blocks must not contain any duplicates.\nAnd if an ID literal is present an ID attribute must not be used. Ignores class attributes.\n\n```pug\n//- Invalid\ndiv(a='a' a='b')\n#id(id='id')\n\n//- Valid\ndiv(class='a', class='b')\n.class(class='class')\n```\n"
         },
         "disallowHtmlText": {
-            "description": "Pug must not contain any HTML text.",
-            "documentation": "# disallowHtmlText: `true`\n\nPug must not contain any HTML text.\n\n```pug\n//- Invalid\n<strong>html text</strong>\np this is <strong>html</strong> text\n```\n",
             "enum": [
                 null,
                 true
-            ]
+            ],
+            "description": "Pug must not contain any HTML text.",
+            "documentation": "# disallowHtmlText: `true`\n\nPug must not contain any HTML text.\n\n```pug\n//- Invalid\n<strong>html text</strong>\np this is <strong>html</strong> text\n```\n"
         },
         "disallowIdAttributeWithStaticValue": {
-            "description": "Prefer ID literals over `id` attributes with static values.",
-            "documentation": "# disallowIdAttributeWithStaticValue: `true`\n\nPrefer ID literals over `id` attributes with static values.\n\n```pug\n//- Invalid\nspan(id='foo')\n\n//- Valid\nspan#id\n```\n",
             "enum": [
                 null,
                 true
-            ]
+            ],
+            "description": "Prefer ID literals over `id` attributes with static values.",
+            "documentation": "# disallowIdAttributeWithStaticValue: `true`\n\nPrefer ID literals over `id` attributes with static values.\n\n```pug\n//- Invalid\nspan(id='foo')\n\n//- Valid\nspan#id\n```\n"
         },
         "disallowIdLiteralsBeforeAttributes": {
-            "description": "All attribute blocks must be written before any ID literals.",
-            "documentation": "# disallowIdLiteralsBeforeAttributes: `true`\n\nAll attribute blocks must be written before any ID literals.\n\n```pug\n//- Invalid\ninput#id(type='text')\n\n//- Valid\ninput(type='text')#id\n```\n",
             "enum": [
                 null,
                 true
-            ]
+            ],
+            "description": "All attribute blocks must be written before any ID literals.",
+            "documentation": "# disallowIdLiteralsBeforeAttributes: `true`\n\nAll attribute blocks must be written before any ID literals.\n\n```pug\n//- Invalid\ninput#id(type='text')\n\n//- Valid\ninput(type='text')#id\n```\n"
         },
         "disallowIdLiterals": {
-            "description": "Pug must not contain any ID literals.",
-            "documentation": "# disallowIdLiterals: `true`\n\nPug must not contain any ID literals.\n\n```pug\n//- Invalid\n#id\n\n//- Valid\ndiv(id='id')\n```\n",
             "enum": [
                 null,
                 true
-            ]
+            ],
+            "description": "Pug must not contain any ID literals.",
+            "documentation": "# disallowIdLiterals: `true`\n\nPug must not contain any ID literals.\n\n```pug\n//- Invalid\n#id\n\n//- Valid\ndiv(id='id')\n```\n"
         },
         "disallowLegacyMixinCall": {
-            "description": "The Pug template must not contain legacy mixin call.",
-            "documentation": "# disallowLegacyMixinCall: `true`\n\nThe Pug template must not contain legacy mixin call.\n\n```pug\n//- Invalid\nmixin myMixin(arg)\n\n//- Valid mixin call\n+myMixin(arg)\n\n//- Valid mixin call with block attached\n+myMixin(arg)\n  p Hey\n\n//- Valid mixin definition\nmixin myMixin(arg)\n  p Hey\n```\n",
             "enum": [
                 null,
                 true
-            ]
+            ],
+            "description": "The Pug template must not contain legacy mixin call.",
+            "documentation": "# disallowLegacyMixinCall: `true`\n\nThe Pug template must not contain legacy mixin call.\n\n```pug\n//- Invalid\nmixin myMixin(arg)\n\n//- Valid mixin call\n+myMixin(arg)\n\n//- Valid mixin call with block attached\n+myMixin(arg)\n  p Hey\n\n//- Valid mixin definition\nmixin myMixin(arg)\n  p Hey\n```\n"
         },
         "disallowMultipleLineBreaks": {
-            "description": "Pug must not contain multiple blank lines in a row.",
-            "documentation": "# disallowMultipleLineBreaks: `true`\n\nPug must not contain multiple blank lines in a row.\n\n```pug\n//- Invalid\ndiv\n\n\ndiv\n\n//- Valid\ndiv\n\ndiv\n```\n",
             "enum": [
                 null,
                 true
-            ]
+            ],
+            "description": "Pug must not contain multiple blank lines in a row.",
+            "documentation": "# disallowMultipleLineBreaks: `true`\n\nPug must not contain multiple blank lines in a row.\n\n```pug\n//- Invalid\ndiv\n\n\ndiv\n\n//- Valid\ndiv\n\ndiv\n```\n"
         },
         "disallowSpaceAfterCodeOperator": {
-            "description": "No code operators (`-`/`=`/`!=`) should be followed by any spaces.",
-            "documentation": "# disallowSpaceAfterCodeOperator: `true` | `Array`\n\n## e.g.: `true`\n\nNo code operators (`-`/`=`/`!=`) should be followed by any spaces.\n\n```pug\n//- Invalid\np= 'This code is <escaped>'\np!=  'This code is <strong>not</strong> escaped'\n\n//- Valid\np='This code is <escaped>'\np!='This code is <strong>not</strong> escaped'\n```\n\n## e.g.: `[ \"-\" ]`\n\nNo unbuffered code operators (`-`) should be followed by any spaces.\n\n```pug\n//- Invalid\n- var a = 'This is code'\n\n//- Valid\n-var a = 'This is code'\n```\n",
             "anyOf": [
                 {
                     "enum": [
@@ -156,19 +161,19 @@
                         ]
                     }
                 }
-            ]
+            ],
+            "description": "No code operators (`-`/`=`/`!=`) should be followed by any spaces.",
+            "documentation": "# disallowSpaceAfterCodeOperator: `true` | `Array`\n\n## e.g.: `true`\n\nNo code operators (`-`/`=`/`!=`) should be followed by any spaces.\n\n```pug\n//- Invalid\np= 'This code is <escaped>'\np!=  'This code is <strong>not</strong> escaped'\n\n//- Valid\np='This code is <escaped>'\np!='This code is <strong>not</strong> escaped'\n```\n\n## e.g.: `[ \"-\" ]`\n\nNo unbuffered code operators (`-`) should be followed by any spaces.\n\n```pug\n//- Invalid\n- var a = 'This is code'\n\n//- Valid\n-var a = 'This is code'\n```\n"
         },
         "disallowSpacesInsideAttributeBrackets": {
-            "description": "Disallows space after opening attribute bracket and before closing.",
-            "documentation": "# disallowSpacesInsideAttributeBrackets: `true`\n\nDisallows space after opening attribute bracket and before closing.\n\n```pug\n//- Invalid\ninput( type='text' name='name' value='value' )\n\n//- Valid\ninput(type='text' name='name' value='value')\n```\n",
             "enum": [
                 null,
                 true
-            ]
+            ],
+            "description": "Disallows space after opening attribute bracket and before closing.",
+            "documentation": "# disallowSpacesInsideAttributeBrackets: `true`\n\nDisallows space after opening attribute bracket and before closing.\n\n```pug\n//- Invalid\ninput( type='text' name='name' value='value' )\n\n//- Valid\ninput(type='text' name='name' value='value')\n```\n"
         },
         "disallowSpecificAttributes": {
-            "description": "Pug must not contain any of the attributes specified.",
-            "documentation": "# disallowSpecificAttributes: `string` | `Array`\n\n## e.g.: `\"a\"` OR `[ \"A\", \"b\" ]`\n\nPug must not contain any of the attributes specified.\n\n```pug\n//- Invalid\nspan(a='a')\ndiv(B='b')\n```\n\n## e.g.: `[ { img: [ \"title\" ] } ]`\n\n`img` tags must not contain any of the attributes specified.\n\n```pug\n//- Invalid\nimg(title='title')\n```\n",
             "type": [
                 "null",
                 "string",
@@ -188,11 +193,11 @@
                         "type": "string"
                     }
                 }
-            }
+            },
+            "description": "Pug must not contain any of the attributes specified.",
+            "documentation": "# disallowSpecificAttributes: `string` | `Array`\n\n## e.g.: `\"a\"` OR `[ \"A\", \"b\" ]`\n\nPug must not contain any of the attributes specified.\n\n```pug\n//- Invalid\nspan(a='a')\ndiv(B='b')\n```\n\n## e.g.: `[ { img: [ \"title\" ] } ]`\n\n`img` tags must not contain any of the attributes specified.\n\n```pug\n//- Invalid\nimg(title='title')\n```\n"
         },
         "disallowSpecificTags": {
-            "description": "Pug must not contain any of the tags specified.",
-            "documentation": "# disallowSpecificTags: `string` | `Array`\n\nPug must not contain any of the tags specified.\n\n## e.g.: `[ \"b\", \"i\" ]`\n\n```pug\n//- Invalid\nb Bold text\ni Italic text\n```\n",
             "type": [
                 "null",
                 "string",
@@ -200,101 +205,101 @@
             ],
             "items": {
                 "type": "string"
-            }
+            },
+            "description": "Pug must not contain any of the tags specified.",
+            "documentation": "# disallowSpecificTags: `string` | `Array`\n\nPug must not contain any of the tags specified.\n\n## e.g.: `[ \"b\", \"i\" ]`\n\n```pug\n//- Invalid\nb Bold text\ni Italic text\n```\n"
         },
         "disallowStringConcatenation": {
-            "description": "Pug must not contain any string concatenation.",
-            "documentation": "# disallowStringConcatenation: `true` | `'aggressive'`\n\nPug must not contain any string concatenation.\n\n```pug\n//- Invalid\nh1= title + \\'text\\'\n//- Invalid under `'aggressive'`\nh1= title + text\n```\n",
             "enum": [
                 null,
                 true,
                 "aggressive"
-            ]
+            ],
+            "description": "Pug must not contain any string concatenation.",
+            "documentation": "# disallowStringConcatenation: `true` | `'aggressive'`\n\nPug must not contain any string concatenation.\n\n```pug\n//- Invalid\nh1= title + \\'text\\'\n//- Invalid under `'aggressive'`\nh1= title + text\n```\n"
         },
         "disallowStringInterpolation": {
-            "description": "Pug must not contain any string interpolation operators.",
-            "documentation": "# disallowStringInterpolation: `true`\n\nPug must not contain any string interpolation operators.\n\n```pug\n//- Invalid\nh1 #{title} text\n```\n",
             "enum": [
                 null,
                 true
-            ]
+            ],
+            "description": "Pug must not contain any string interpolation operators.",
+            "documentation": "# disallowStringInterpolation: `true`\n\nPug must not contain any string interpolation operators.\n\n```pug\n//- Invalid\nh1 #{title} text\n```\n"
         },
         "disallowTagInterpolation": {
-            "description": "Pug must not contain any tag interpolation operators.",
-            "documentation": "# disallowTagInterpolation: `true`\n\nPug must not contain any tag interpolation operators.\n\n```pug\n//- Invalid\n| #[strong html] text\np #[strong html] text\n```\n",
             "enum": [
                 null,
                 true
-            ]
+            ],
+            "description": "Pug must not contain any tag interpolation operators.",
+            "documentation": "# disallowTagInterpolation: `true`\n\nPug must not contain any tag interpolation operators.\n\n```pug\n//- Invalid\n| #[strong html] text\np #[strong html] text\n```\n"
         },
         "disallowTemplateString": {
-            "description": "Pug must not contain template strings. `true` only fails when a template\nstring is used directly; `'all'` fails when template strings are used at\nall.",
-            "documentation": "# disallowTemplateString: `true` | `'all'`\n\nPug must not contain template strings. `true` only fails when a template\nstring is used directly; `'all'` fails when template strings are used at\nall.\n\n## e.g. `true`\n\n```pug\n//- Invalid\nh1= `${title} text`\n\n//- Valid\nh1= translate(`${title} text`)\n```\n\n## e.g. `'all'`\n\n```pug\n//- Invalid\nh1= translate(`${title} text`)\n```\n",
             "enum": [
                 null,
                 true,
                 "all"
-            ]
+            ],
+            "description": "Pug must not contain template strings. `true` only fails when a template\nstring is used directly; `'all'` fails when template strings are used at\nall.",
+            "documentation": "# disallowTemplateString: `true` | `'all'`\n\nPug must not contain template strings. `true` only fails when a template\nstring is used directly; `'all'` fails when template strings are used at\nall.\n\n## e.g. `true`\n\n```pug\n//- Invalid\nh1= `${title} text`\n\n//- Valid\nh1= translate(`${title} text`)\n```\n\n## e.g. `'all'`\n\n```pug\n//- Invalid\nh1= translate(`${title} text`)\n```\n"
         },
         "maximumNumberOfLines": {
-            "description": "Pug files should be at most the number of lines specified.",
-            "documentation": "# maximumNumberOfLines: `int`\n\nPug files should be at most the number of lines specified.\n",
             "type": [
                 "null",
                 "integer"
-            ]
+            ],
+            "description": "Pug files should be at most the number of lines specified.",
+            "documentation": "# maximumNumberOfLines: `int`\n\nPug files should be at most the number of lines specified.\n"
         },
         "requireClassLiteralsBeforeAttributes": {
-            "description": "All class literals must be written before any attribute blocks.",
-            "documentation": "# requireClassLiteralsBeforeAttributes: `true`\n\nAll class literals must be written before any attribute blocks.\n\n```pug\n//- Invalid\ninput(type='text').class\n\n//- Valid\ninput.class(type='text')\n```\n",
             "enum": [
                 null,
                 true
-            ]
+            ],
+            "description": "All class literals must be written before any attribute blocks.",
+            "documentation": "# requireClassLiteralsBeforeAttributes: `true`\n\nAll class literals must be written before any attribute blocks.\n\n```pug\n//- Invalid\ninput(type='text').class\n\n//- Valid\ninput.class(type='text')\n```\n"
         },
         "requireClassLiteralsBeforeIdLiterals": {
-            "description": "All class literals must be written before any ID literals.",
-            "documentation": "# requireClassLiteralsBeforeIdLiterals: `true`\n\nAll class literals must be written before any ID literals.\n\n```pug\n//- Invalid\ninput#id.class(type='text')\n\n//- Valid\ninput.class#id(type='text')\n```\n",
             "enum": [
                 null,
                 true
-            ]
+            ],
+            "description": "All class literals must be written before any ID literals.",
+            "documentation": "# requireClassLiteralsBeforeIdLiterals: `true`\n\nAll class literals must be written before any ID literals.\n\n```pug\n//- Invalid\ninput#id.class(type='text')\n\n//- Valid\ninput.class#id(type='text')\n```\n"
         },
         "requireIdLiteralsBeforeAttributes": {
-            "description": "All ID literals must be written before any attribute blocks.",
-            "documentation": "# requireIdLiteralsBeforeAttributes: `true`\n\nAll ID literals must be written before any attribute blocks.\n\n```pug\n//- Invalid\ninput(type='text')#id\n\n//- Valid\ninput#id(type='text')\n```\n",
             "enum": [
                 null,
                 true
-            ]
+            ],
+            "description": "All ID literals must be written before any attribute blocks.",
+            "documentation": "# requireIdLiteralsBeforeAttributes: `true`\n\nAll ID literals must be written before any attribute blocks.\n\n```pug\n//- Invalid\ninput(type='text')#id\n\n//- Valid\ninput#id(type='text')\n```\n"
         },
         "requireLineFeedAtFileEnd": {
-            "description": "All files must end with a line feed.",
-            "documentation": "# requireLineFeedAtFileEnd: `true`\n\nAll files must end with a line feed.\n",
             "enum": [
                 null,
                 true
-            ]
+            ],
+            "description": "All files must end with a line feed.",
+            "documentation": "# requireLineFeedAtFileEnd: `true`\n\nAll files must end with a line feed.\n"
         },
         "requireLowerCaseAttributes": {
-            "description": "All attributes must be written in lower case. Files with `doctype xml` are ignored.",
-            "documentation": "# requireLowerCaseAttributes: `true`\n\nAll attributes must be written in lower case. Files with `doctype xml` are ignored.\n\n```pug\n//- Invalid\ndiv(Class='class')\n\n//- Valid\ndiv(class='class')\n```\n",
             "enum": [
                 null,
                 true
-            ]
+            ],
+            "description": "All attributes must be written in lower case. Files with `doctype xml` are ignored.",
+            "documentation": "# requireLowerCaseAttributes: `true`\n\nAll attributes must be written in lower case. Files with `doctype xml` are ignored.\n\n```pug\n//- Invalid\ndiv(Class='class')\n\n//- Valid\ndiv(class='class')\n```\n"
         },
         "requireLowerCaseTags": {
-            "description": "All tags must be written in lower case. Files with `doctype xml` are ignored.",
-            "documentation": "# requireLowerCaseTags: `true`\n\nAll tags must be written in lower case. Files with `doctype xml` are ignored.\n\n```pug\n//- Invalid\nDiv(class='class')\n\n//- Valid\ndiv(class='class')\n```\n",
             "enum": [
                 null,
                 true
-            ]
+            ],
+            "description": "All tags must be written in lower case. Files with `doctype xml` are ignored.",
+            "documentation": "# requireLowerCaseTags: `true`\n\nAll tags must be written in lower case. Files with `doctype xml` are ignored.\n\n```pug\n//- Invalid\nDiv(class='class')\n\n//- Valid\ndiv(class='class')\n```\n"
         },
         "requireSpaceAfterCodeOperator": {
-            "description": "All code operators (`-`/`=`/`!=`) must be immediately followed by a single space.",
-            "documentation": "# requireSpaceAfterCodeOperator: `true` | `Array`\n\n## e.g.: `true`\n\nAll code operators (`-`/`=`/`!=`) must be immediately followed by a single space.\n\n```pug\n//- Invalid\np='This code is <escaped>'\np!=  'This code is <strong>not</strong> escaped'\n\n//- Valid\np= 'This code is <escaped>'\np!= 'This code is <strong>not</strong> escaped'\n```\n\n## e.g.: `[ \"-\" ]`\n\nAll unbuffered code operators (`-`) must be immediately followed by a single space.\n\n```pug\n//- Invalid\n-var a = 'This is code'\n\n//- Valid\n- var a = 'This is code'\n```\n",
             "anyOf": [
                 {
                     "enum": [
@@ -312,19 +317,19 @@
                         ]
                     }
                 }
-            ]
+            ],
+            "description": "All code operators (`-`/`=`/`!=`) must be immediately followed by a single space.",
+            "documentation": "# requireSpaceAfterCodeOperator: `true` | `Array`\n\n## e.g.: `true`\n\nAll code operators (`-`/`=`/`!=`) must be immediately followed by a single space.\n\n```pug\n//- Invalid\np='This code is <escaped>'\np!=  'This code is <strong>not</strong> escaped'\n\n//- Valid\np= 'This code is <escaped>'\np!= 'This code is <strong>not</strong> escaped'\n```\n\n## e.g.: `[ \"-\" ]`\n\nAll unbuffered code operators (`-`) must be immediately followed by a single space.\n\n```pug\n//- Invalid\n-var a = 'This is code'\n\n//- Valid\n- var a = 'This is code'\n```\n"
         },
         "requireSpacesInsideAttributeBrackets": {
-            "description": "Requires space after opening attribute bracket and before closing.",
-            "documentation": "# requireSpacesInsideAttributeBrackets: `true`\n\nRequires space after opening attribute bracket and before closing.\n\n```pug\n//- Invalid\ninput(type='text' name='name' value='value')\n\n//- Valid\ninput( type='text' name='name' value='value' )\n```\n",
             "enum": [
                 null,
                 true
-            ]
+            ],
+            "description": "Requires space after opening attribute bracket and before closing.",
+            "documentation": "# requireSpacesInsideAttributeBrackets: `true`\n\nRequires space after opening attribute bracket and before closing.\n\n```pug\n//- Invalid\ninput(type='text' name='name' value='value')\n\n//- Valid\ninput( type='text' name='name' value='value' )\n```\n"
         },
         "requireSpecificAttributes": {
-            "description": "`img` tags must contain all of the attributes specified.",
-            "documentation": "# requireSpecificAttributes: `Array`\n\n## e.g.: `[ { img: [ \"alt\" ] } ]`\n\n`img` tags must contain all of the attributes specified.\n\n```pug\n//- Invalid\nimg(src='src')\n\n//- Valid\nimg(src='src' alt='alt')\n```\n",
             "type": [
                 "null",
                 "array"
@@ -337,29 +342,29 @@
                         "type": "string"
                     }
                 }
-            }
+            },
+            "description": "`img` tags must contain all of the attributes specified.",
+            "documentation": "# requireSpecificAttributes: `Array`\n\n## e.g.: `[ { img: [ \"alt\" ] } ]`\n\n`img` tags must contain all of the attributes specified.\n\n```pug\n//- Invalid\nimg(src='src')\n\n//- Valid\nimg(src='src' alt='alt')\n```\n"
         },
         "requireStrictEqualityOperators": {
-            "description": "Requires the use of `===` and `!==` instead of `==` and `!=`.",
-            "documentation": "# requireStrictEqualityOperators: `true`\n\nRequires the use of `===` and `!==` instead of `==` and `!=`.\n\n```pug\n//- Invalid\nif true == false\nif true != false\n\n//- Valid\nif true === false\nif true !== false\n```\n",
             "enum": [
                 null,
                 true
-            ]
+            ],
+            "description": "Requires the use of `===` and `!==` instead of `==` and `!=`.",
+            "documentation": "# requireStrictEqualityOperators: `true`\n\nRequires the use of `===` and `!==` instead of `==` and `!=`.\n\n```pug\n//- Invalid\nif true == false\nif true != false\n\n//- Valid\nif true === false\nif true !== false\n```\n"
         },
         "validateAttributeQuoteMarks": {
-            "description": "All attribute values must be enclosed in single quotes.",
-            "documentation": "# validateAttributeQuoteMarks: `\"\\\"\"` | `\"'\"` | `true`\n\n## e.g.: `\"'\"`\n\nAll attribute values must be enclosed in single quotes.\n\n```pug\n//- Invalid\ninput(type=\"text\" name=\"name\" value=\"value\")\n\n//- Valid\ninput(type='text' name='name' value='value')\n```\n\n## if (true)\n\nAll attribute values must be enclosed in quote marks match the first quote mark encountered in the source code.\n",
             "enum": [
                 null,
                 "\"",
                 "'",
                 true
-            ]
+            ],
+            "description": "All attribute values must be enclosed in single quotes.",
+            "documentation": "# validateAttributeQuoteMarks: `\"\\\"\"` | `\"'\"` | `true`\n\n## e.g.: `\"'\"`\n\nAll attribute values must be enclosed in single quotes.\n\n```pug\n//- Invalid\ninput(type=\"text\" name=\"name\" value=\"value\")\n\n//- Valid\ninput(type='text' name='name' value='value')\n```\n\n## if (true)\n\nAll attribute values must be enclosed in quote marks match the first quote mark encountered in the source code.\n"
         },
         "validateAttributeSeparator": {
-            "description": "* All attributes must be immediately followed by a comma and then a space.\n* All attributes must be on the same line.",
-            "documentation": "# validateAttributeSeparator: `string` | `object`\n\n## e.g.: `\", \"`\n\n* All attributes must be immediately followed by a comma and then a space.\n* All attributes must be on the same line.\n\n```pug\n//- Invalid\ninput(type='text' name='name' value='value')\ndiv\n  input(type='text'\n  , name='name'\n  , value='value'\n  )\n\n//- Valid\ninput(type='text', name='name', value='value')\n```\n\n## e.g.: `{ \"separator\": \" \", \"multiLineSeparator\": \"\\n  \" }`\n\n* All attributes that are on the same line must be immediately followed by a space.\n* All attributes that are on different lines must be preceded by two spaces.\n\n```pug\n//- Invalid\ninput(type='text', name='name', value='value')\ndiv\n  input(type='text'\n  , name='name'\n  , value='value'\n  )\n\n//- Valid\ninput(type='text' name='name' value='value')\ndiv\n  input(type='text'\n    name='name'\n    value='value'\n)\n```\n",
             "type": [
                 "null",
                 "string",
@@ -372,27 +377,27 @@
                 "multiLineSeparator": {
                     "type": "string"
                 }
-            }
+            },
+            "description": "* All attributes must be immediately followed by a comma and then a space.\n* All attributes must be on the same line.",
+            "documentation": "# validateAttributeSeparator: `string` | `object`\n\n## e.g.: `\", \"`\n\n* All attributes must be immediately followed by a comma and then a space.\n* All attributes must be on the same line.\n\n```pug\n//- Invalid\ninput(type='text' name='name' value='value')\ndiv\n  input(type='text'\n  , name='name'\n  , value='value'\n  )\n\n//- Valid\ninput(type='text', name='name', value='value')\n```\n\n## e.g.: `{ \"separator\": \" \", \"multiLineSeparator\": \"\\n  \" }`\n\n* All attributes that are on the same line must be immediately followed by a space.\n* All attributes that are on different lines must be preceded by two spaces.\n\n```pug\n//- Invalid\ninput(type='text', name='name', value='value')\ndiv\n  input(type='text'\n  , name='name'\n  , value='value'\n  )\n\n//- Valid\ninput(type='text' name='name' value='value')\ndiv\n  input(type='text'\n    name='name'\n    value='value'\n)\n```\n"
         },
         "validateDivTags": {
-            "description": "Checks that Pug does not contain any unnecessary `div` tags.",
-            "documentation": "# validateDivTags: `true`\n\nChecks that Pug does not contain any unnecessary `div` tags.\n\n```pug\n//- Invalid\ndiv.class\ndiv#id\ndiv.class(class='class')\n\n//- Valid\n.class\n#id\n.class(class='class')\n```\n",
             "enum": [
                 null,
                 true
-            ]
+            ],
+            "description": "Checks that Pug does not contain any unnecessary `div` tags.",
+            "documentation": "# validateDivTags: `true`\n\nChecks that Pug does not contain any unnecessary `div` tags.\n\n```pug\n//- Invalid\ndiv.class\ndiv#id\ndiv.class(class='class')\n\n//- Valid\n.class\n#id\n.class(class='class')\n```\n"
         },
         "validateExtensions": {
-            "description": "Pug template must use proper file extensions with inclusion and inheritance\n(`.pug`).",
-            "documentation": "# validateExtensions: `true`\n\nPug template must use proper file extensions with inclusion and inheritance\n(`.pug`).\n\n```pug\n//- Invalid\ninclude a\ninclude a.jade\nextends a\nextends a.txt\nextends a.jade\n\n//- Valid\ninclude a.txt\ninclude a.pug\nextends a.pug\n```\n",
             "enum": [
                 null,
                 true
-            ]
+            ],
+            "description": "Pug template must use proper file extensions with inclusion and inheritance\n(`.pug`).",
+            "documentation": "# validateExtensions: `true`\n\nPug template must use proper file extensions with inclusion and inheritance\n(`.pug`).\n\n```pug\n//- Invalid\ninclude a\ninclude a.jade\nextends a\nextends a.txt\nextends a.jade\n\n//- Valid\ninclude a.txt\ninclude a.pug\nextends a.pug\n```\n"
         },
         "validateIndentation": {
-            "description": "Indentation must be consistently two spaces.",
-            "documentation": "# validateIndentation: `int` | `\"\\t\"`\n\n## e.g.: `2`\n\nIndentation must be consistently two spaces.\n\n```pug\n//- Invalid\ndiv\n<TAB>div\n\n//- Valid\ndiv\n<SPACE><SPACE>div\n```\n\n## e.g.: `\"\\t\"`\n\nIndentation must be consistently tabs.\n\n```pug\n//- Invalid\ndiv\n<SPACE><SPACE>div\n\n//- Valid\ndiv\n<TAB>div\n```\n",
             "anyOf": [
                 {
                     "enum": [
@@ -403,29 +408,29 @@
                 {
                     "type": "integer"
                 }
-            ]
+            ],
+            "description": "Indentation must be consistently two spaces.",
+            "documentation": "# validateIndentation: `int` | `\"\\t\"`\n\n## e.g.: `2`\n\nIndentation must be consistently two spaces.\n\n```pug\n//- Invalid\ndiv\n<TAB>div\n\n//- Valid\ndiv\n<SPACE><SPACE>div\n```\n\n## e.g.: `\"\\t\"`\n\nIndentation must be consistently tabs.\n\n```pug\n//- Invalid\ndiv\n<SPACE><SPACE>div\n\n//- Valid\ndiv\n<TAB>div\n```\n"
         },
         "validateLineBreaks": {
-            "description": "All line break characters must match.",
-            "documentation": "# validateLineBreaks: `\"CR\"` | `\"LF\"` | `\"CRLF\"`\n\n## e.g.: `\"LF\"`\n\nAll line break characters must match.\n\n```pug\n//- Invalid\ndiv(class='class')<CRLF>\n.button\n\n//- Valid\ndiv(class='class')<LF>\n.button\n```\n",
             "enum": [
                 null,
                 "CR",
                 "LF",
                 "CRLF"
-            ]
+            ],
+            "description": "All line break characters must match.",
+            "documentation": "# validateLineBreaks: `\"CR\"` | `\"LF\"` | `\"CRLF\"`\n\n## e.g.: `\"LF\"`\n\nAll line break characters must match.\n\n```pug\n//- Invalid\ndiv(class='class')<CRLF>\n.button\n\n//- Valid\ndiv(class='class')<LF>\n.button\n```\n"
         },
         "validateSelfClosingTags": {
-            "description": "Checks that Pug does not contain any\n[unnecessary self closing tags](http://www.w3.org/html/wg/drafts/html/master/syntax.html#void-elements).\nFiles with `doctype xml` are ignored.",
-            "documentation": "# validateSelfClosingTags: `true`\n\nChecks that Pug does not contain any\n[unnecessary self closing tags](http://www.w3.org/html/wg/drafts/html/master/syntax.html#void-elements).\nFiles with `doctype xml` are ignored.\n\n```pug\n//- Invalid\narea/\nlink/\n\n//- Valid\narea\nlink\nfoo/\n\ndoctype xml\narea/\n```\n",
             "enum": [
                 null,
                 true
-            ]
+            ],
+            "description": "Checks that Pug does not contain any\n[unnecessary self closing tags](http://www.w3.org/html/wg/drafts/html/master/syntax.html#void-elements).\nFiles with `doctype xml` are ignored.",
+            "documentation": "# validateSelfClosingTags: `true`\n\nChecks that Pug does not contain any\n[unnecessary self closing tags](http://www.w3.org/html/wg/drafts/html/master/syntax.html#void-elements).\nFiles with `doctype xml` are ignored.\n\n```pug\n//- Invalid\narea/\nlink/\n\n//- Valid\narea\nlink\nfoo/\n\ndoctype xml\narea/\n```\n"
         },
         "validateTemplateString": {
-            "description": "Validate the use of template string in Pug templates.",
-            "documentation": "# validateTemplateString: `true` | Array\n\nValidate the use of template string in Pug templates.\n\nThe option can either be an array or `true`. If it is an array, it can\ncontain the following strings. If it is `true` signifies all of the\nfollowing subrules are enabled.\n\n## `'variable'`\n\n```pug\n//- Invalid\nh1= `${title}`\n\n//- Valid\nh1= title\n```\n\n## `'string'`\n\n```pug\n//- Invalid\nh1= `title`\n\n//- Valid\nh1= 'title'\n```\n\n## `'concatenation'`\n\n```pug\n//- Invalid\nh1= `title` + `text`\nh1= `title` + variable\n\n//- Valid\nh1= `titletext`\nh1= `title${variable}`\n```",
             "anyOf": [
                 {
                     "enum": [
@@ -443,7 +448,9 @@
                         ]
                     }
                 }
-            ]
+            ],
+            "description": "Validate the use of template string in Pug templates.",
+            "documentation": "# validateTemplateString: `true` | Array\n\nValidate the use of template string in Pug templates.\n\nThe option can either be an array or `true`. If it is an array, it can\ncontain the following strings. If it is `true` signifies all of the\nfollowing subrules are enabled.\n\n## `'variable'`\n\n```pug\n//- Invalid\nh1= `${title}`\n\n//- Valid\nh1= title\n```\n\n## `'string'`\n\n```pug\n//- Invalid\nh1= `title`\n\n//- Valid\nh1= 'title'\n```\n\n## `'concatenation'`\n\n```pug\n//- Invalid\nh1= `title` + `text`\nh1= `title` + variable\n\n//- Valid\nh1= `titletext`\nh1= `title${variable}`\n```\n"
         }
     }
 }


### PR DESCRIPTION
This PR adds a JSON schema for `pug-lintrc` files.  The goal is to enable great code-completion and documentation within an editor or IDE.  Here's an example of this in Visual Studio Code:

<img width="562" alt="screen shot 2016-11-18 at 2 22 10 am" src="https://cloud.githubusercontent.com/assets/376504/20422101/4af06fb6-ad36-11e6-8b7f-80cc816798b9.png">
<img width="822" alt="screen shot 2016-11-18 at 2 21 49 am" src="https://cloud.githubusercontent.com/assets/376504/20422107/50922e46-ad36-11e6-9d9e-1a48824d713b.png">

This is using a version of VSCode's puglint extension that's been modified to declare this JSON schema should be used for `.pug-lint.json` files.  It's a 4-line declaration in `package.json`.  After that, the schema and VSCode do all the work.  Other editors probably support something similar.

Let me know if you have any questions!