### PR TITLE
Update README.md to reference gulp-pug-lint2

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ let g:syntastic_pug_checkers = ['pug_lint']
 
 ### Gulp
 
-If you're using Gulp as your build system, you can use [gulp-pug-lint](https://github.com/emartech/gulp-pug-lint) for easier integration.
+If you're using Gulp as your build system, you can use [gulp-pug-lint2](https://github.com/jwalton/gulp-pug-lint2) for easier integration.
 
 ### Grunt
 


### PR DESCRIPTION
This PR updates README.md to suggest gulp-pug-lint2 instead of gulp-pug-lint.

gulp-pug-lint hasn't seen any updates in 2 years.  It:

* [forces you to use pug-lint@2.1.2](https://github.com/emartech/gulp-pug-lint/blob/master/package.json#L21) which doesn't support es6 syntax, despite two PRs to try to update package dependencies, both of which are well over a year old.
* [doesn't have support for failing on errors](https://github.com/emartech/gulp-pug-lint/pull/10) despite a PR from April.
* [reads the .pug template files from disk](https://github.com/emartech/gulp-pug-lint/blob/506153aefa756aded48baebc3fbb4c7140b8dba7/index.js#L30) even though the contents of the file are already in memory `file.contents`, which makes it slow.

gulp-pug-lint2, on the other hand, uses peer dependencies so you can use whatever pug-lint you want to use.  It also users `puglint.checkString()` to check the contents in the vinyl File buffer provided to us by gulp, instead of going back to the disk a second time.  Finally, gulp-pug-lint2 has tests which test actually linting a file, which gulp-pug-lint does not.