### PR TITLE
Fix problem with extending scoped config packages

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -13,6 +13,10 @@ exports.normalizePackageName = function (name, prefix) {
     name = path.normalize(name).replace(/\\/g, '/');
   }
 
+  if (name.indexOf('@') === 0) {
+    return name;
+  }
+
   if (name.indexOf(prefix + '-') !== 0) {
     name = prefix + '-' + name;
   }


### PR DESCRIPTION
Fixes problem with extending @scoped config packages like `@myscope/pug-lint-config-myconfig`.

The only way to extend a scoped config package at the moment is to write out the path relative to cwd:
``` json
{
  "extends": "./node_modules/@myscope/pug-lint-config-myconfig/index.js"
}
```

This fix allows extending config like this:
``` json
{
  "extends": "@myscope/pug-lint-config-myconfig"
}
```