### PR TITLE
Added greedy pattern matching when validating attribute separators

### DIFF
--- a/lib/rules/validate-attribute-separator.js
+++ b/lib/rules/validate-attribute-separator.js
@@ -129,7 +129,10 @@ module.exports.prototype = {
 
     function getParsedSource(current, start, end, patterns) {
       var source = file.getSourceBetweenTokens(current, end).trim();
-      var regexReplace = new RegExp(patterns.join('|'), 'g');
+      var regexReplace = new RegExp(patterns.sort(function (a, b) {
+        // Patterns need to be sorted longest first to make the replace greedy
+        return b.length - a.length;
+      }).join('|'), 'g');
       var regexNewLines = new RegExp('(\\r\\n|\\r|\\n)[ \\t]{' + current._indent + '}', 'g');
 
       source = source.replace(regexReplace, function (val) {

--- a/test/fixtures/invalid.pug
+++ b/test/fixtures/invalid.pug
@@ -1,3 +1,2 @@
-div
-|
+div=
 div

--- a/test/fixtures/reporters/expected-invalid.txt
+++ b/test/fixtures/reporters/expected-invalid.txt
@@ -1,9 +1,8 @@
-%dirname%invalid.pug:2:1
-    1| div
-  > 2| |
--------^
-    3| div
-    4| 
+%dirname%invalid.pug:1:4
+  > 1| div=
+----------^
+    2| div
+    3| 
 
-unexpected text "|
+unexpected text "=
 div"

--- a/test/fixtures/rules/invalid.pug
+++ b/test/fixtures/rules/invalid.pug
@@ -1,3 +1,2 @@
-div
-|
+div=
 div

--- a/test/fixtures/rules/validate-attribute-separator--multiline.pug
+++ b/test/fixtures/rules/validate-attribute-separator--multiline.pug
@@ -23,3 +23,11 @@ div
 div
   div(a="foo", b="bar",
     c="batz")
+
+div(
+  foo,
+  foo-bar="baz")
+
+div(
+  foo,
+  foo-foo="bar")

--- a/test/fixtures/rules/validate-attribute-separator.pug
+++ b/test/fixtures/rules/validate-attribute-separator.pug
@@ -55,3 +55,7 @@ div
     class='class'
     name='name'
   )
+
+div(foo foo-bar="baz")
+
+div(foo foo-foo="bar")

--- a/test/rules/validate-attribute-separator.test.js
+++ b/test/rules/validate-attribute-separator.test.js
@@ -53,7 +53,7 @@ function createTest(linter, fixturesPath) {
       it('should report multiple errors found in file', function () {
         var result = linter.checkFile(fixturePath);
 
-        assert.equal(result.length, 32);
+        assert.equal(result.length, 34);
         assert.equal(result[0].code, 'PUG:LINT_VALIDATEATTRIBUTESEPARATOR');
         assert.equal(result[0].line, 2);
         assert.equal(result[0].column, 18);
@@ -76,7 +76,7 @@ function createTest(linter, fixturesPath) {
       it('should report multiple errors found in file', function () {
         var result = linter.checkFile(fixturePath);
 
-        assert.equal(result.length, 31);
+        assert.equal(result.length, 33);
         assert.equal(result[0].code, 'PUG:LINT_VALIDATEATTRIBUTESEPARATOR');
         assert.equal(result[0].line, 2);
         assert.equal(result[0].column, 18);
@@ -99,7 +99,7 @@ function createTest(linter, fixturesPath) {
       it('should report multiple errors found in file', function () {
         var result = linter.checkFile(fixturePath);
 
-        assert.equal(result.length, 32);
+        assert.equal(result.length, 34);
         assert.equal(result[0].code, 'PUG:LINT_VALIDATEATTRIBUTESEPARATOR');
         assert.equal(result[0].line, 2);
         assert.equal(result[0].column, 18);
@@ -122,7 +122,7 @@ function createTest(linter, fixturesPath) {
       it('should report multiple errors found in file', function () {
         var result = linter.checkFile(fixturePath);
 
-        assert.equal(result.length, 33);
+        assert.equal(result.length, 35);
         assert.equal(result[0].code, 'PUG:LINT_VALIDATEATTRIBUTESEPARATOR');
         assert.equal(result[0].line, 2);
         assert.equal(result[0].column, 18);


### PR DESCRIPTION
Fixes #149 by making token pattern matching greedy. Otherwise, if an attribute named `foo` appears before another attribute named `foo-bar`, the latter attribute would be matched as `foo`, making the `-bar` part look like a separator after `foo` token.

Also fixed unit tests that were failing because `invalid.pug` was no longer invalid.