### PR TITLE
Update to pug-lexer@4 & co, and make unit tests pass again

### DIFF
--- a/lib/pug-file.js
+++ b/lib/pug-file.js
@@ -32,6 +32,12 @@ var PugFile = function (filename, source) {
 
       token._index = index;
       token._indent = currentIndent;
+      if (token.loc) {
+        // Preserve old location data format for backward compatibility with rules.
+        var loc = token.loc.start;
+        token.line = loc.line;
+        token.col = loc.column;
+      }
       return token;
     });
   } catch (e) {

--- a/lib/rules/validate-attribute-separator.js
+++ b/lib/rules/validate-attribute-separator.js
@@ -96,7 +96,7 @@ module.exports.prototype = {
         file.iterateTokensByFilter(function (token) {
           return token.type === 'attribute' && token._index > startIndex && token._index < endIndex;
         }, function (token) {
-          var value = typeof token.val === 'boolean' ? '' : token.val;
+          var value = typeof token.val === 'boolean' ? '' : token.val.trim();
 
           patterns.push(getEscapedPattern(token.name) + (value.length > 0 ? '\\s*\\!*=\\s*' : '') +
               getEscapedPattern(value));

--- a/package.json
+++ b/package.json
@@ -88,9 +88,9 @@
     "glob": "^7.0.3",
     "minimatch": "^3.0.3",
     "path-is-absolute": "^1.0.0",
-    "pug-attrs": "^2.0.1",
-    "pug-error": "^1.3.0",
-    "pug-lexer": "^2.0.1",
+    "pug-attrs": "^2.0.3",
+    "pug-error": "^1.3.2",
+    "pug-lexer": "^4.0.0",
     "resolve": "^1.1.7",
     "strip-json-comments": "^2.0.1",
     "void-elements": "^2.0.1"

--- a/test/fixtures/invalid.pug
+++ b/test/fixtures/invalid.pug
@@ -1,3 +1,1 @@
-div
-|
-div
+div=#

--- a/test/fixtures/reporters/expected-invalid.txt
+++ b/test/fixtures/reporters/expected-invalid.txt
@@ -1,9 +1,6 @@
-%dirname%invalid.pug:2:1
-    1| div
-  > 2| |
--------^
-    3| div
-    4| 
+%dirname%invalid.pug:1:5
+  > 1| div=#
+-----------^
+    2| 
 
-unexpected text "|
-div"
+Syntax Error: Unexpected character '#'

--- a/test/fixtures/rules/invalid.pug
+++ b/test/fixtures/rules/invalid.pug
@@ -1,3 +1,1 @@
-div
-|
-div
+div=#

--- a/test/linter.test.js
+++ b/test/linter.test.js
@@ -99,7 +99,7 @@ describe('linter', function () {
       var result = linter.checkFile(fixturesPath + 'invalid.pug');
 
       assert.equal(result.length, 1);
-      assert.equal(result[0].code, 'PUG:UNEXPECTED_TEXT');
+      assert.equal(result[0].code, 'PUG:SYNTAX_ERROR');
     });
   });
 
@@ -118,14 +118,14 @@ describe('linter', function () {
       var result = linter.checkPath(fixturesPath + 'invalid.pug');
 
       assert.equal(result.length, 1);
-      assert.equal(result[0].code, 'PUG:UNEXPECTED_TEXT');
+      assert.equal(result[0].code, 'PUG:SYNTAX_ERROR');
     });
 
     it('should report errors for directory path', function () {
       var result = linter.checkPath(fixturesPath);
 
       assert.equal(result.length, 2);
-      assert.equal(result[0].code, 'PUG:UNEXPECTED_TEXT');
+      assert.equal(result[0].code, 'PUG:SYNTAX_ERROR');
     });
 
     it('should not report errors for default excluded directory path', function () {


### PR DESCRIPTION
Relates to #148, but makes unit tests pass again by adjusting code for internal pug changes:

- Lexer returns lines / columns in a different format, with sometimes slightly different values than before
- This is now valid syntax in pug 2:
    ```pug
    div
    |
    div
    ```