### PR TITLE
Allow ellipsis in attribute names

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,9 +88,9 @@
     "glob": "^7.0.3",
     "minimatch": "^3.0.3",
     "path-is-absolute": "^1.0.0",
-    "pug-attrs": "^2.0.3",
-    "pug-error": "^1.3.2",
-    "pug-lexer": "^4.0.0",
+    "pug-attrs": "^2.0.4",
+    "pug-error": "^1.3.3",
+    "pug-lexer": "^4.1.0",
     "resolve": "^1.1.7",
     "strip-json-comments": "^2.0.1",
     "void-elements": "^2.0.1"

--- a/test/rules/validate-attribute-separator.test.js
+++ b/test/rules/validate-attribute-separator.test.js
@@ -35,6 +35,23 @@ function createTest(linter, fixturesPath) {
           linter.checkString('input(*ngIf=\'editing\' type=\'text\' name=\'name\' value=\'value\')');
         }, /Invalid regular expression/);
       });
+
+      describe('with ellipsis mark in name', () => {
+        it('reports invalid attribute separator', () => {
+          const result = linter.checkString('input(type=\'text\'  ...props name=\'name\')');
+
+          assert.equal(result.length, 1);
+          assert.equal(result[0].code, 'PUG:LINT_VALIDATEATTRIBUTESEPARATOR');
+          assert.equal(result[0].line, 1);
+          assert.equal(result[0].column, 18);
+        });
+
+        it('does not report with valid separator', function () {
+          const result = linter.checkString('input(...props type=\'text\' ...props name=\'name\' value=\'value\' ...props)');
+
+          assert.equal(result.length, 0);
+        });
+      });
     });
 
     describe('comma', function () {


### PR DESCRIPTION
Some time back `pug-lexer` got an improvement, it started supporting ellipsis in attribute names. Related pull request: https://github.com/pugjs/pug/pull/3152

As pug-lint relies on `pug-lexer` it makes sense to upgrade it as well.

In addition I added test case to catch the issue in the future.