### PR TITLE
Remove dependency semver-regex

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,6 @@
     "pliers": "^1.2.1",
     "pug-lint-config-clock": "^1.1.0",
     "rimraf": "^2.5.2",
-    "semver-regex": "^1.0.0",
     "sinon": "^1.17.2",
     "xo": "^0.15.1",
     "yeoman-generator": "^0.23.3",

--- a/pliers/build-changelog.js
+++ b/pliers/build-changelog.js
@@ -4,7 +4,6 @@ var fs = require('fs');
 var path = require('path');
 var changelog = require('changelog');
 var moment = require('moment');
-var semverRegex = require('semver-regex');
 var packageDetails = require('../package.json');
 
 function createTask(pliers) {
@@ -37,7 +36,7 @@ function createTask(pliers) {
           var message = change.message.split('\n')[0];
 
           if (message) {
-            if (semverRegex().test(message)) {
+            if (/^(.*\s)?v?[0-9]+\.[0-9]+\.[0-9]+(\s.*)?$/.test(message)) {
               previousVersion = message;
 
               if (previousVersion.length) {


### PR DESCRIPTION
This npm package has 2 vulnerabilities: CVE-2021-3795 + CVE-2021-43307. It was imported just to use a regex. The present commit makes use of a much simpler regex, without any extra package requirement.

I tested that `npm run changelog` still works fine when creationg a new version.