### PR TITLE
Use HTTPS URL to publish on npm registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "url": "git@github.com:pugjs/pug-lint.git"
   },
   "publishConfig": {
-    "registry": "http://registry.npmjs.org"
+    "registry": "https://registry.npmjs.org"
   },
   "main": "./lib/linter",
   "bin": {


### PR DESCRIPTION
Otherwise `npm publish` is rejected.